### PR TITLE
API: failed slots chunks

### DIFF
--- a/packages/api/src/router/indexer.ts
+++ b/packages/api/src/router/indexer.ts
@@ -101,7 +101,7 @@ export const indexerRouter = createTRPCRouter({
           z.object({
             hash: z.string(),
             from: z.string(),
-            to: z.string(),
+            to: z.string().optional(),
             blockNumber: z.coerce.number(),
           }),
         ),

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Transaction {
   id        String          @id
   hash      String          @unique
   from      String
-  to        String
+  to        String?
   blockNumber Int
   blobs      Blob[]
   block     Block  @relation(fields: [blockNumber], references: [number])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10,11 +10,6 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Config {
-  id          Int         @id @default(autoincrement())
-  lastSlot    Int         @unique
-}
-
 model Blob {
   id          Int         @id @default(autoincrement())
   versionedHash String
@@ -43,6 +38,17 @@ model Transaction {
   blockNumber Int
   blobs      Blob[]
   block     Block  @relation(fields: [blockNumber], references: [number])
+}
+
+model IndexerMetadata {
+  id          Int         @id @default(autoincrement())
+  lastSlot    Int
+}
+
+model IndexerFailedSlotsChunk {
+  id          Int         @id @default(autoincrement())
+  initialSlot Int         @unique
+  finalSlot   Int         @unique
 }
 
 


### PR DESCRIPTION
This PR adds changes to the database to start tracking failed slots chunks submitted by the indexer and endpoints to update and remove them. 