### PR TITLE
Fix PORT variable

### DIFF
--- a/apps/rest-api-server/src/openapi.ts
+++ b/apps/rest-api-server/src/openapi.ts
@@ -2,14 +2,14 @@ import { generateOpenApiDocument } from "trpc-openapi";
 
 import { appRouter } from "@blobscan/api";
 
-import { PORT } from "./env";
+import { env } from "./env";
 
 // Generate OpenAPI schema document
 export const openApiDocument = generateOpenApiDocument(appRouter, {
   title: "Blobscan API",
   description: "OpenAPI compliant REST API built using tRPC with Express",
   version: "0.0.1",
-  baseUrl: `http://localhost:${PORT}/api`,
+  baseUrl: `http://localhost:${env.BLOBSCAN_API_PORT}/api`,
   docsUrl: "https://docs-blobscan-com.vercel.app/",
   tags: ["auth", "blocks", "blobs", "transactions"],
 });


### PR DESCRIPTION
```
/app/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
src/openapi.ts(5,10): error TS2305: Module '"./env"' has no exported member 'PORT'.

    at createTSError (/app/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/app/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/app/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/app/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/app/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Object.require.extensions.<computed> [as .ts] (/app/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Function.Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19) {
  diagnosticCodes: [ 2305 ]
```