### PR TITLE
Logic retrieving either BEE_ENDPOINT or BEE_DEBUG_ENDPOINT

### DIFF
--- a/packages/blob-storage-manager/src/storages/SwarmStorage.ts
+++ b/packages/blob-storage-manager/src/storages/SwarmStorage.ts
@@ -86,7 +86,7 @@ export class SwarmStorage extends BlobStorage {
       return;
     }
 
-    if (!env.BEE_ENDPOINT) {
+    if (!env.BEE_ENDPOINT && !env.BEE_DEBUG_ENDPOINT) {
       console.warn("Swarm storage enabled but no bee endpoint was provided");
       return;
     }

--- a/packages/blob-storage-manager/src/storages/SwarmStorage.ts
+++ b/packages/blob-storage-manager/src/storages/SwarmStorage.ts
@@ -37,7 +37,7 @@ export class SwarmStorage extends BlobStorage {
       healthCheckOps.push(
         this.#swarmClient.beeDebug.getHealth().then((health) => {
           if (health.status !== "ok") {
-            throw new Error(`Bee debug is not healthy: ${health.status}`);
+            throw new Error(`Bee debug endpoint is not healthy: ${health.status}`);
           }
         })
       );


### PR DESCRIPTION
One of both must be given when enabling swarm blob storage.