### PR TITLE
chore(web): enable conditional env vars validation

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,8 +1,5 @@
-/**
- * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.
- * This is especially useful for Docker builds and Linting.
- */
-// !process.env.SKIP_ENV_VALIDATION && (await import("./src/env.mjs"));
+// Importing env files here to validate on build
+import "./src/env.mjs";
 
 /** @type {import("next").NextConfig} */
 const config = {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,6 @@
     "@blobscan/db": "^0.0.1",
     "@blobscan/open-telemetry": "^0.0.1",
     "@blobscan/tailwind-config": "^0.0.1",
-    "@blobscan/zod": "^0.0.1",
     "@fontsource/inter": "^4.5.15",
     "@fontsource/public-sans": "^4.5.12",
     "@headlessui/react": "^1.7.13",

--- a/apps/web/src/env.mjs
+++ b/apps/web/src/env.mjs
@@ -1,8 +1,6 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
-import { booleanSchema, optionalStringSchema } from "@blobscan/zod";
-
 export const env = createEnv({
   /**
    * Specify your server-side environment variables schema here. This way you can ensure the app isn't
@@ -10,12 +8,13 @@ export const env = createEnv({
    */
   server: {
     DATABASE_URL: z.string().url(),
-    BEACON_NODE_ENDPOINT: optionalStringSchema(
-      z.string().url(),
-      "http://localhost:5052"
-    ),
+    BEACON_NODE_ENDPOINT: z.string().url(),
     NODE_ENV: z.enum(["development", "test", "production"]),
-    TRACES_ENABLED: optionalStringSchema(booleanSchema(), false),
+    TRACES_ENABLED: z
+      .string()
+      .default("false")
+      .refine((s) => s === "true" || s === "false" || s == "")
+      .transform((s) => s === "true"),
   },
   /**
    * Specify your client-side environment variables schema here.
@@ -38,4 +37,5 @@ export const env = createEnv({
     NEXT_PUBLIC_BEACON_BASE_URL: process.env.NEXT_PUBLIC_BEACON_BASE_URL,
     TRACES_ENABLED: process.env.TRACES_ENABLED,
   },
+  skipValidation: !!process.env.CI || !!process.env.SKIP_ENV_VALIDATION,
 });

--- a/apps/web/src/env.mjs
+++ b/apps/web/src/env.mjs
@@ -12,7 +12,6 @@ export const env = createEnv({
     NODE_ENV: z.enum(["development", "test", "production"]),
     TRACES_ENABLED: z
       .string()
-      .default("false")
       .refine((s) => s === "true" || s === "false" || s == "")
       .transform((s) => s === "true"),
   },

--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -15,27 +15,17 @@ function defaultTransformer(defaultValue: unknown) {
 }
 
 export function booleanSchema() {
-  const schema: z.ZodType = z.string();
-
-  return schema.transform((arg, ctx): boolean => {
-    const varName = ctx.path[0];
-    const arg_ = arg.toLowerCase();
-
-    if (!arg_.length) {
-      return false;
-    }
-
-    if (arg_ !== "true" && arg_ !== "false") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `${varName} must be either true or false`,
-      });
-
-      return z.NEVER;
-    }
-
-    return arg_ === "true";
-  });
+  return z
+    .string()
+    .default("false")
+    .refine(
+      (s) =>
+        s === "true" ||
+        s === "false" ||
+        // Allow declared but unset env vars to be treated as false
+        s == ""
+    )
+    .transform((s) => s === "true");
 }
 
 export function optionalStringSchema(

--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -17,7 +17,6 @@ function defaultTransformer(defaultValue: unknown) {
 export function booleanSchema() {
   return z
     .string()
-    .default("false")
     .refine(
       (s) =>
         s === "true" ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,9 +198,6 @@ importers:
       '@blobscan/tailwind-config':
         specifier: ^0.0.1
         version: link:../../packages/config/tailwind
-      '@blobscan/zod':
-        specifier: ^0.0.1
-        version: link:../../packages/zod
       '@fontsource/inter':
         specifier: ^4.5.15
         version: 4.5.15


### PR DESCRIPTION
This PR validates web app env vars, which were never done before.

The validation can also be bypassed by setting`SKIP_ENV_VALIDATION` or running it as part of a GitHub Actions workflow.

It also removes the `@blobscan/zod` package as nextjs config files doesn't get along with ts files