### PR TITLE
Use t3's env var validation package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
 
-# TODO: Get rid of this variable
-ENV SECRET_KEY supersecret
-
 RUN apk add bash curl
 RUN npm install -g pnpm
 WORKDIR /app

--- a/apps/rest-api-server/api/env.ts
+++ b/apps/rest-api-server/api/env.ts
@@ -1,26 +1,19 @@
-import { z, createEnvSchema, booleanSchema } from "@blobscan/zod";
+import {
+  booleanSchema,
+  createEnv,
+  nodeEnvSchema,
+  makeOptional,
+  portSchema,
+  presetEnvOptions,
+} from "@blobscan/zod";
 
-const envSchema = createEnvSchema({
-  BLOBSCAN_API_PORT: {
-    schema: z.coerce.number().int().positive(),
-    default: 3001,
+export const env = createEnv({
+  server: {
+    BLOBSCAN_API_PORT: makeOptional(portSchema, 3001),
+    NODE_ENV: makeOptional(nodeEnvSchema),
+    METRICS_ENABLED: makeOptional(booleanSchema, true),
+    TRACES_ENABLED: makeOptional(booleanSchema, false),
   },
-  NODE_ENV: {
-    schema: z.enum(["development", "test", "production"]),
-    optional: true,
-  },
-  METRICS_ENABLED: {
-    schema: booleanSchema(),
-    optional: true,
-    default: true,
-  },
-  TRACES_ENABLED: {
-    schema: booleanSchema(),
-    optional: true,
-    default: false,
-  },
+
+  ...presetEnvOptions,
 });
-
-export const env = envSchema.parse(process.env);
-
-export type Environment = z.infer<typeof envSchema>;

--- a/packages/api/src/clients/trpc.ts
+++ b/packages/api/src/clients/trpc.ts
@@ -4,6 +4,7 @@ import type { OpenApiMeta } from "trpc-openapi";
 import { ZodError } from "zod";
 
 import type { TRPCContext } from "../context";
+import { env } from "../env";
 
 export const t = initTRPC
   .context<TRPCContext>()
@@ -13,7 +14,7 @@ export const t = initTRPC
     errorFormatter({ shape, error }) {
       if (
         error.code === "INTERNAL_SERVER_ERROR" &&
-        process.env.NODE_ENV === "production"
+        env.NODE_ENV === "production"
       ) {
         return { ...shape, message: "Internal server error" };
       }

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -1,9 +1,16 @@
-import { z, createEnvSchema } from "@blobscan/zod";
+import {
+  z,
+  createEnv,
+  makeOptional,
+  nodeEnvSchema,
+  presetEnvOptions,
+} from "@blobscan/zod";
 
-const envSchema = createEnvSchema({
-  SECRET_KEY: { schema: z.string() },
+export const env = createEnv({
+  server: {
+    SECRET_KEY: z.string(),
+    NODE_ENV: makeOptional(nodeEnvSchema),
+  },
+
+  ...presetEnvOptions,
 });
-
-export const env = envSchema.parse(process.env);
-
-export type Environment = z.infer<typeof envSchema>;

--- a/packages/api/src/router/indexer/indexData/schema.ts
+++ b/packages/api/src/router/indexer/indexData/schema.ts
@@ -1,4 +1,4 @@
-import { stringToBigIntSchema, z } from "@blobscan/zod";
+import { toBigIntSchema, z } from "@blobscan/zod";
 
 export const indexDataInputSchema = z.object({
   block: z.object({
@@ -6,8 +6,8 @@ export const indexDataInputSchema = z.object({
     hash: z.string(),
     timestamp: z.coerce.number(),
     slot: z.coerce.number(),
-    blobGasUsed: stringToBigIntSchema(),
-    excessBlobGas: stringToBigIntSchema(),
+    blobGasUsed: toBigIntSchema,
+    excessBlobGas: toBigIntSchema,
   }),
   transactions: z.array(
     z.object({
@@ -15,8 +15,8 @@ export const indexDataInputSchema = z.object({
       from: z.string(),
       to: z.string(),
       blockNumber: z.coerce.number(),
-      gasPrice: stringToBigIntSchema(),
-      maxFeePerBlobGas: stringToBigIntSchema(),
+      gasPrice: toBigIntSchema,
+      maxFeePerBlobGas: toBigIntSchema,
     })
   ),
   blobs: z.array(

--- a/packages/blob-storage-manager/src/env.ts
+++ b/packages/blob-storage-manager/src/env.ts
@@ -2,25 +2,26 @@ import {
   z,
   chainIdSchema,
   booleanSchema,
-  createEnvSchema,
+  createEnv,
+  makeOptional,
+  presetEnvOptions,
 } from "@blobscan/zod";
 
-const envSchema = createEnvSchema({
-  BEE_DEBUG_ENDPOINT: { schema: z.string().url(), optional: true },
-  BEE_ENDPOINT: { schema: z.string().url(), optional: true },
-  CHAIN_ID: { schema: chainIdSchema(), default: 7011893058 },
-  GOOGLE_STORAGE_BUCKET_NAME: { optional: true },
-  GOOGLE_STORAGE_PROJECT_ID: { optional: true },
-  GOOGLE_SERVICE_KEY: { optional: true },
-  GOOGLE_STORAGE_API_ENDPOINT: {
-    schema: z.string().url(),
-    optional: true,
+export const env = createEnv({
+  server: {
+    BEE_DEBUG_ENDPOINT: makeOptional(z.string().url()),
+    BEE_ENDPOINT: makeOptional(z.string().url()),
+    CHAIN_ID: makeOptional(chainIdSchema, 7011893058),
+    GOOGLE_STORAGE_BUCKET_NAME: makeOptional(z.string()),
+    GOOGLE_STORAGE_PROJECT_ID: makeOptional(z.string()),
+    GOOGLE_SERVICE_KEY: makeOptional(z.string()),
+    GOOGLE_STORAGE_API_ENDPOINT: makeOptional(z.string().url()),
+    GOOGLE_STORAGE_ENABLED: makeOptional(booleanSchema, false),
+    POSTGRES_STORAGE_ENABLED: makeOptional(booleanSchema, true),
+    SWARM_STORAGE_ENABLED: makeOptional(booleanSchema, false),
   },
-  GOOGLE_STORAGE_ENABLED: { schema: booleanSchema(), default: false },
-  POSTGRES_STORAGE_ENABLED: { schema: booleanSchema(), default: true },
-  SWARM_STORAGE_ENABLED: { schema: booleanSchema(), default: false },
+
+  ...presetEnvOptions,
 });
 
-export const env = envSchema.parse(process.env);
-
-export type Environment = z.infer<typeof envSchema>;
+export type Environment = typeof env;

--- a/packages/open-telemetry/src/env.ts
+++ b/packages/open-telemetry/src/env.ts
@@ -1,28 +1,21 @@
-import { z, createEnvSchema } from "@blobscan/zod";
+import {
+  createEnv,
+  makeOptional,
+  nodeEnvSchema,
+  presetEnvOptions,
+  z,
+} from "@blobscan/zod";
 
-const envSchema = createEnvSchema({
-  OTEL_EXPORTER_OTLP_PROTOCOL: {
-    schema: z.enum(["grpc", "http/protobuf", "http/json"]),
-    optional: true,
+export const env = createEnv({
+  server: {
+    OTEL_EXPORTER_OTLP_PROTOCOL: makeOptional(
+      z.enum(["grpc", "http/protobuf", "http/json"])
+    ),
+    OTEL_EXPORTER_OTLP_ENDPOINT: makeOptional(z.string().url()),
+    OTLP_AUTH_USERNAME: makeOptional(z.coerce.string()),
+    OTLP_AUTH_PASSWORD: makeOptional(z.string()),
+    NODE_ENV: makeOptional(nodeEnvSchema),
   },
-  OTEL_EXPORTER_OTLP_ENDPOINT: {
-    schema: z.string().url(),
-    optional: true,
-  },
-  OTLP_AUTH_USERNAME: {
-    schema: z.coerce.string(),
-    optional: true,
-  },
-  OTLP_AUTH_PASSWORD: {
-    schema: z.string(),
-    optional: true,
-  },
-  NODE_ENV: {
-    schema: z.enum(["development", "test", "production"]),
-    optional: true,
-  },
+
+  ...presetEnvOptions,
 });
-
-export const env = envSchema.parse(process.env);
-
-export type Environment = z.infer<typeof envSchema>;

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -11,6 +11,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@t3-oss/env-core": "^0.6.1",
     "zod": "^3.21.4"
   },
   "eslintConfig": {

--- a/packages/zod/src/create-env.ts
+++ b/packages/zod/src/create-env.ts
@@ -1,0 +1,6 @@
+export * from "@t3-oss/env-core";
+
+export const presetEnvOptions = {
+  runtimeEnv: process.env,
+  skipValidation: !!process.env.CI || !!process.env.SKIP_ENV_VALIDATION,
+};

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,2 +1,4 @@
-export * from "./schemas";
 export * from "zod";
+
+export * from "./create-env";
+export * from "./schemas";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
 
   packages/zod:
     dependencies:
+      '@t3-oss/env-core':
+        specifier: ^0.6.1
+        version: 0.6.1(typescript@4.9.5)(zod@3.21.4)
       zod:
         specifier: ^3.21.4
         version: 3.21.4


### PR DESCRIPTION
Avoid reinventing the wheel.

This PR updates the codebase to start using t3's env variable validation [package](https://env.t3.gg) instead of our own custom logic.