### PR TITLE
Bring booleanSchema back

### DIFF
--- a/apps/rest-api-server/api/env.ts
+++ b/apps/rest-api-server/api/env.ts
@@ -1,11 +1,11 @@
-import { z, createEnv, presetEnvOptions } from "@blobscan/zod";
+import { z, booleanSchema, createEnv, presetEnvOptions } from "@blobscan/zod";
 
 export const env = createEnv({
   server: {
     BLOBSCAN_API_PORT: z.coerce.number().positive().default(3001),
     NODE_ENV: z.enum(["development", "test", "production"]).optional(),
-    METRICS_ENABLED: z.coerce.boolean().default(true),
-    TRACES_ENABLED: z.coerce.boolean().default(false),
+    METRICS_ENABLED: booleanSchema,
+    TRACES_ENABLED: booleanSchema,
   },
 
   ...presetEnvOptions,

--- a/apps/rest-api-server/api/env.ts
+++ b/apps/rest-api-server/api/env.ts
@@ -4,8 +4,8 @@ export const env = createEnv({
   server: {
     BLOBSCAN_API_PORT: z.coerce.number().positive().default(3001),
     NODE_ENV: z.enum(["development", "test", "production"]).optional(),
-    METRICS_ENABLED: booleanSchema,
-    TRACES_ENABLED: booleanSchema,
+    METRICS_ENABLED: booleanSchema.default("true"),
+    TRACES_ENABLED: booleanSchema.default("false"),
   },
 
   ...presetEnvOptions,

--- a/apps/web/src/env.mjs
+++ b/apps/web/src/env.mjs
@@ -1,8 +1,6 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
-import { booleanSchema } from "@blobscan/zod";
-
 export const env = createEnv({
   /**
    * Specify your server-side environment variables schema here. This way you can ensure the app isn't
@@ -11,7 +9,12 @@ export const env = createEnv({
   server: {
     DATABASE_URL: z.string().url(),
     NODE_ENV: z.enum(["development", "test", "production"]),
-    TRACES_ENABLED: booleanSchema,
+    // See booleanSchema from packages/zod/src/schemas.ts
+    TRACES_ENABLED: z
+      .string()
+      .refine((s) => s === "true" || s === "false")
+      .transform((s) => s === "true")
+      .default("false"),
   },
   /**
    * Specify your client-side environment variables schema here.

--- a/apps/web/src/env.mjs
+++ b/apps/web/src/env.mjs
@@ -1,6 +1,8 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+import { booleanSchema } from "@blobscan/zod";
+
 export const env = createEnv({
   /**
    * Specify your server-side environment variables schema here. This way you can ensure the app isn't
@@ -9,7 +11,7 @@ export const env = createEnv({
   server: {
     DATABASE_URL: z.string().url(),
     NODE_ENV: z.enum(["development", "test", "production"]),
-    TRACES_ENABLED: z.coerce.boolean(),
+    TRACES_ENABLED: booleanSchema,
   },
   /**
    * Specify your client-side environment variables schema here.
@@ -17,8 +19,14 @@ export const env = createEnv({
    */
   client: {
     NEXT_PUBLIC_NETWORK_NAME: z.string().default("Ethereum"),
-    NEXT_PUBLIC_EXPLORER_BASE_URL: z.string().url().default("https://etherscan.io/"),
-    NEXT_PUBLIC_BEACON_BASE_URL: z.string().url().default("https://beaconcha.in/"),
+    NEXT_PUBLIC_EXPLORER_BASE_URL: z
+      .string()
+      .url()
+      .default("https://etherscan.io/"),
+    NEXT_PUBLIC_BEACON_BASE_URL: z
+      .string()
+      .url()
+      .default("https://beaconcha.in/"),
   },
   /**
    * Destructure all variables from `process.env` to make sure they aren't tree-shaken away.

--- a/packages/blob-storage-manager/src/env.ts
+++ b/packages/blob-storage-manager/src/env.ts
@@ -1,8 +1,4 @@
-import {
-  z,
-  createEnv,
-  presetEnvOptions,
-} from "@blobscan/zod";
+import { z, booleanSchema, createEnv, presetEnvOptions } from "@blobscan/zod";
 
 export const env = createEnv({
   server: {
@@ -13,9 +9,9 @@ export const env = createEnv({
     GOOGLE_STORAGE_PROJECT_ID: z.string().optional(),
     GOOGLE_SERVICE_KEY: z.string().optional(),
     GOOGLE_STORAGE_API_ENDPOINT: z.string().optional(),
-    GOOGLE_STORAGE_ENABLED: z.coerce.boolean().default(false),
-    POSTGRES_STORAGE_ENABLED: z.coerce.boolean().default(true),
-    SWARM_STORAGE_ENABLED: z.coerce.boolean().default(false),
+    GOOGLE_STORAGE_ENABLED: booleanSchema,
+    POSTGRES_STORAGE_ENABLED: booleanSchema,
+    SWARM_STORAGE_ENABLED: booleanSchema,
   },
 
   ...presetEnvOptions,

--- a/packages/blob-storage-manager/src/env.ts
+++ b/packages/blob-storage-manager/src/env.ts
@@ -9,9 +9,9 @@ export const env = createEnv({
     GOOGLE_STORAGE_PROJECT_ID: z.string().optional(),
     GOOGLE_SERVICE_KEY: z.string().optional(),
     GOOGLE_STORAGE_API_ENDPOINT: z.string().optional(),
-    GOOGLE_STORAGE_ENABLED: booleanSchema,
-    POSTGRES_STORAGE_ENABLED: booleanSchema,
-    SWARM_STORAGE_ENABLED: booleanSchema,
+    GOOGLE_STORAGE_ENABLED: booleanSchema.default("false"),
+    POSTGRES_STORAGE_ENABLED: booleanSchema.default("true"),
+    SWARM_STORAGE_ENABLED: booleanSchema.default("false"),
   },
 
   ...presetEnvOptions,

--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -14,4 +14,12 @@ function defaultTransformer(defaultValue: unknown) {
   };
 }
 
+// We use this workaround instead of z.coerce.boolean.default(false)
+// because it considers as "true" any value different than "false"
+// (including the empty string).
+export const booleanSchema = z
+  .string()
+  .refine((s) => s === "true" || s === "false")
+  .transform((s) => s === "true");
+
 export const toBigIntSchema = z.string().transform((value) => BigInt(value));


### PR DESCRIPTION
We use this workaround instead of `z.coerce.boolean.default(false)` because it considers as "true" any value different than "false" (including the empty string).
