### PR TITLE
fix: add our own function to convert a hexadecimal string to utf-8

### DIFF
--- a/apps/web/src/pages/blob/[hash].tsx
+++ b/apps/web/src/pages/blob/[hash].tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import type { NextPage } from "next";
 import NextError from "next/error";
 import { useRouter } from "next/router";
-import { utils } from "ethers";
 
 import "react-loading-skeleton/dist/skeleton.css";
 import Skeleton from "react-loading-skeleton";
@@ -14,7 +13,7 @@ import { ExpandableContent } from "~/components/ExpandableContent";
 import type { DetailsLayoutProps } from "~/components/Layouts/DetailsLayout";
 import { DetailsLayout } from "~/components/Layouts/DetailsLayout";
 import { api } from "~/api-client";
-import { formatBytes } from "~/utils";
+import { formatBytes, hexStringToUtf8 } from "~/utils";
 
 type BlobViewMode = "Original" | "UTF-8";
 
@@ -25,7 +24,7 @@ function formatBlob(blob: string, viewMode: BlobViewMode): string {
     case "Original":
       return blob;
     case "UTF-8":
-      return utils.toUtf8String(blob).replace(/\0/g, "");
+      return hexStringToUtf8(blob);
     default:
       return blob;
   }

--- a/apps/web/src/utils/text.ts
+++ b/apps/web/src/utils/text.ts
@@ -4,3 +4,18 @@ export function capitalize(str: string): string {
   }
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+
+export function hexStringToUtf8(hexString: string): string {
+  const byteArray = hexString.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16));
+
+  if (!byteArray) {
+    throw new Error("Invalid hexadecimal string");
+  }
+
+  const uint8Array = new Uint8Array(byteArray);
+  const textDecoder = new TextDecoder("utf-8");
+  const utf8String = textDecoder.decode(uint8Array);
+
+  return utf8String;
+}


### PR DESCRIPTION
ethers.js implementation raises an exception as soon as one of the characters cannot be utf-8 decoded

See https://blobscan.com/blob/0x01eb50cbcd04004b89d42cbaeed19b9728d7498ada756c675f4f658e4d0f847a

![image](https://github.com/Blobscan/blobscan/assets/73274/63d3195e-6a85-425e-9e8f-dd7a4b7270dd)
