### PR TITLE
Block details

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@blobscan/api": "^0.0.1",
     "@blobscan/dayjs": "^0.0.1",
-    "@blobscan/db": "^0.0.1",
     "@blobscan/open-telemetry": "^0.0.1",
     "@blobscan/tailwind-config": "^0.0.1",
     "@fontsource/inter": "^4.5.15",

--- a/apps/web/src/components/BlobGasUsage.tsx
+++ b/apps/web/src/components/BlobGasUsage.tsx
@@ -1,0 +1,58 @@
+import type { FC } from "react";
+
+import {
+  BLOB_GAS_LIMIT_PER_BLOCK,
+  TARGET_BLOB_GAS_PER_BLOCK,
+  calculateBlobGasTarget,
+  calculatePercentage,
+  formatNumber,
+} from "~/utils";
+import { PercentageBar } from "./PercentageBar";
+
+type BlobGasUsageProps = {
+  blobGasUsed: bigint;
+};
+
+export const BlobGasUsage: FC<BlobGasUsageProps> = function ({ blobGasUsed }) {
+  const blobGasUsedPercentage = calculatePercentage(
+    blobGasUsed,
+    BigInt(BLOB_GAS_LIMIT_PER_BLOCK)
+  );
+  const blobGasTarget = calculateBlobGasTarget(blobGasUsed);
+  const targetSign = blobGasUsed < TARGET_BLOB_GAS_PER_BLOCK ? "-" : "+";
+  const isPositive = targetSign === "+";
+
+  return (
+    <div className="flex gap-2">
+      <div>
+        {formatNumber(blobGasUsed)}
+        <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
+          (
+          {formatNumber(blobGasUsedPercentage, "standard", {
+            maximumFractionDigits: 2,
+          })}
+          %)
+        </span>
+      </div>
+      <div className={`flex items-center gap-1`}>
+        <PercentageBar
+          className={
+            isPositive
+              ? "bg-positive-light dark:bg-positive-dark"
+              : "bg-negative-light dark:bg-negative-dark"
+          }
+          percentage={blobGasUsedPercentage / 100}
+        />
+        <span
+          className={
+            isPositive
+              ? "text-positive-light dark:text-positive-dark"
+              : "text-negative-light dark:text-negative-dark"
+          }
+        >
+          {targetSign} {blobGasTarget.toFixed(2)}% Blob Gas Target
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/Charts/Block/DailyAvgBlobFeeChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyAvgBlobFeeChart.tsx
@@ -23,7 +23,7 @@ export const DailyAvgBlobFeeChart: FC<Partial<DailyAvgBlobFeeChartProps>> =
       ...buildTimeSeriesOptions({
         dates: days,
         axisFormatters: {
-          yAxisTooltip: (value) => `${formatNumber(value)} gwei`,
+          yAxisTooltip: (value) => `${formatNumber(value)} Gwei`,
         },
         yUnit: "ethereum",
       }),

--- a/apps/web/src/components/Charts/Block/DailyAvgBlobGasPriceChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyAvgBlobGasPriceChart.tsx
@@ -23,7 +23,7 @@ export const DailyAvgBlobGasPriceChart: FC<
     ...buildTimeSeriesOptions({
       dates: days,
       axisFormatters: {
-        yAxisTooltip: (value) => `${formatNumber(value)} gwei`,
+        yAxisTooltip: (value) => `${formatNumber(value)} Gwei`,
       },
       yUnit: "ethereum",
     }),

--- a/apps/web/src/components/Charts/Block/DailyBlobFeeChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyBlobFeeChart.tsx
@@ -22,7 +22,7 @@ export const DailyBlobFeeChart: FC<Partial<DailyBlobFeeChartProps>> =
       ...buildTimeSeriesOptions({
         dates: days,
         axisFormatters: {
-          yAxisTooltip: (value) => `${formatNumber(value)} gwei`,
+          yAxisTooltip: (value) => `${formatNumber(value)} Gwei`,
         },
         yUnit: "ethereum",
       }),

--- a/apps/web/src/components/PercentageBar.tsx
+++ b/apps/web/src/components/PercentageBar.tsx
@@ -1,0 +1,30 @@
+import type { FC, HTMLAttributes } from "react";
+import { animated, useSpring } from "@react-spring/web";
+
+export type PercentageBarProps = {
+  className?: HTMLAttributes<HTMLDivElement>["className"];
+  percentage: number;
+};
+
+export const PercentageBar: FC<PercentageBarProps> = function ({
+  percentage,
+  className,
+}) {
+  const percentageProps = useSpring({
+    value: percentage * 96,
+    from: { value: 0 },
+    cancel: !percentage,
+  });
+
+  return (
+    <div className="relative">
+      <div className="h-1.5 w-24 rounded-md bg-primary-200 dark:bg-primary-800" />
+      <animated.div
+        className={`absolute top-0 h-1.5 rounded-md ${className}`}
+        style={{
+          width: percentageProps.value.to((x) => `${x}px`),
+        }}
+      />
+    </div>
+  );
+};

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -19,6 +19,7 @@ import {
   gasTarget,
   GAS_PER_BLOB,
   GAS_LIMIT_PER_BLOCK,
+  MAX_BLOBS_PER_BLOCK,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -149,9 +150,9 @@ const Block: NextPage = function () {
                   name: "Blob Gas Limit",
                   value: (
                     <div>
-                      {formatNumber(786432)}
+                      {formatNumber(GAS_LIMIT_PER_BLOCK)}
                       <span className="ml-1 text-gray-500">
-                        (6 blobs per block)
+                        ({formatNumber(MAX_BLOBS_PER_BLOCK)} blobs per block)
                       </span>
                     </div>
                   ),

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -4,6 +4,7 @@ import NextError from "next/error";
 import { useRouter } from "next/router";
 import type { NextRouter } from "next/router";
 
+import { BlobGasUsage } from "~/components/BlobGasUsage";
 import { Card } from "~/components/Cards/Card";
 import { BlobTransactionCard } from "~/components/Cards/SurfaceCards/BlobTransactionCard";
 import { DetailsLayout } from "~/components/Layouts/DetailsLayout";
@@ -16,12 +17,8 @@ import {
   formatNumber,
   formatTimestamp,
   formatWei,
-  calculateBlobGasTarget,
   GAS_PER_BLOB,
   MAX_BLOBS_PER_BLOCK,
-  TARGET_BLOB_GAS_PER_BLOCK,
-  calculatePercentage,
-  BLOB_GAS_LIMIT_PER_BLOCK,
   performDiv,
   pluralize,
 } from "~/utils";
@@ -113,7 +110,7 @@ const Block: NextPage = function () {
                   value: (
                     <div>
                       {formatBytes(totalBlobSize)}
-                      <span className="ml-1 text-gray-500">
+                      <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
                         ({formatNumber(totalBlobSize / GAS_PER_BLOB)}{" "}
                         {pluralize("blob", totalBlobSize / GAS_PER_BLOB)})
                       </span>
@@ -125,7 +122,7 @@ const Block: NextPage = function () {
                   value: (
                     <div>
                       {formatWei(blockData.blobGasPrice, { toUnit: "ether" })}
-                      <span className="ml-1 text-gray-500">
+                      <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
                         ({formatWei(blockData.blobGasPrice)})
                       </span>
                     </div>
@@ -133,35 +130,14 @@ const Block: NextPage = function () {
                 },
                 {
                   name: "Blob Gas Used",
-                  value: (
-                    <div>
-                      {formatNumber(blockData.blobGasUsed)}
-                      <span className="ml-1 text-gray-500">
-                        (
-                        {formatNumber(
-                          calculatePercentage(
-                            blockData.blobGasUsed,
-                            BigInt(BLOB_GAS_LIMIT_PER_BLOCK)
-                          ).toFixed(2),
-                          "standard",
-                          { maximumFractionDigits: 2 }
-                        )}
-                        %)
-                      </span>{" "}
-                      {blockData.blobGasUsed < TARGET_BLOB_GAS_PER_BLOCK
-                        ? "-"
-                        : "+"}
-                      {calculateBlobGasTarget(blockData.blobGasUsed).toFixed(2)}
-                      % Blob Gas Target
-                    </div>
-                  ),
+                  value: <BlobGasUsage blobGasUsed={blockData.blobGasUsed} />,
                 },
                 {
                   name: "Blob Gas Limit",
                   value: (
                     <div>
                       {formatNumber(MAX_BLOBS_PER_BLOCK)}
-                      <span className="ml-1 text-gray-500">
+                      <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
                         ({formatNumber(MAX_BLOBS_PER_BLOCK)}{" "}
                         {pluralize("blob", MAX_BLOBS_PER_BLOCK)} per block)
                       </span>
@@ -173,7 +149,7 @@ const Block: NextPage = function () {
                   value: (
                     <div>
                       {formatNumber(blockData.blobAsCalldataGasUsed)}
-                      <span className="ml-1">
+                      <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
                         (
                         <strong>
                           {formatNumber(

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -16,10 +16,12 @@ import {
   formatNumber,
   formatTimestamp,
   formatWei,
-  gasTarget,
+  calculateBlobGasTarget,
   GAS_PER_BLOB,
   GAS_LIMIT_PER_BLOCK,
   MAX_BLOBS_PER_BLOCK,
+  getBlobGasTargetSign,
+  TARGET_BLOB_GAS_PER_BLOCK,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -142,7 +144,11 @@ const Block: NextPage = function () {
                         )}
                         %)
                       </span>{" "}
-                      {gasTarget(blockData.blobGasUsed)}
+                      {blockData.blobGasUsed < TARGET_BLOB_GAS_PER_BLOCK
+                        ? "-"
+                        : "+"}
+                      {calculateBlobGasTarget(blockData.blobGasUsed).toString()}
+                      % Blob Gas Target
                     </div>
                   ),
                 },

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -18,10 +18,11 @@ import {
   formatWei,
   calculateBlobGasTarget,
   GAS_PER_BLOB,
-  GAS_LIMIT_PER_BLOCK,
   MAX_BLOBS_PER_BLOCK,
-  getBlobGasTargetSign,
   TARGET_BLOB_GAS_PER_BLOCK,
+  calculatePercentage,
+  BLOB_GAS_LIMIT_PER_BLOCK,
+  performDiv,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -112,8 +113,7 @@ const Block: NextPage = function () {
                     <div>
                       {formatBytes(totalBlobSize)}
                       <span className="ml-1 text-gray-500">
-                        ({formatNumber(BigInt(totalBlobSize) / GAS_PER_BLOB)}{" "}
-                        blobs)
+                        ({formatNumber(totalBlobSize / GAS_PER_BLOB)} blobs)
                       </span>
                     </div>
                   ),
@@ -137,8 +137,10 @@ const Block: NextPage = function () {
                       <span className="ml-1 text-gray-500">
                         (
                         {formatNumber(
-                          (blockData.blobGasUsed * BigInt(100)) /
-                            GAS_LIMIT_PER_BLOCK,
+                          calculatePercentage(
+                            blockData.blobGasUsed,
+                            BigInt(BLOB_GAS_LIMIT_PER_BLOCK)
+                          ).toFixed(2),
                           "standard",
                           { maximumFractionDigits: 2 }
                         )}
@@ -147,7 +149,7 @@ const Block: NextPage = function () {
                       {blockData.blobGasUsed < TARGET_BLOB_GAS_PER_BLOCK
                         ? "-"
                         : "+"}
-                      {calculateBlobGasTarget(blockData.blobGasUsed).toString()}
+                      {calculateBlobGasTarget(blockData.blobGasUsed).toFixed(2)}
                       % Blob Gas Target
                     </div>
                   ),
@@ -156,7 +158,7 @@ const Block: NextPage = function () {
                   name: "Blob Gas Limit",
                   value: (
                     <div>
-                      {formatNumber(GAS_LIMIT_PER_BLOCK)}
+                      {formatNumber(MAX_BLOBS_PER_BLOCK)}
                       <span className="ml-1 text-gray-500">
                         ({formatNumber(MAX_BLOBS_PER_BLOCK)} blobs per block)
                       </span>
@@ -172,8 +174,10 @@ const Block: NextPage = function () {
                         (
                         <strong>
                           {formatNumber(
-                            blockData.blobAsCalldataGasUsed /
-                              blockData.blobGasUsed,
+                            performDiv(
+                              blockData.blobAsCalldataGasUsed,
+                              blockData.blobGasUsed
+                            ),
                             "standard",
                             { maximumFractionDigits: 2 }
                           )}

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -18,6 +18,7 @@ import {
   formatWei,
   gasTarget,
   GAS_PER_BLOB,
+  GAS_LIMIT_PER_BLOCK,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -134,7 +135,7 @@ const Block: NextPage = function () {
                         (
                         {formatNumber(
                           (blockData.blobGasUsed * BigInt(100)) /
-                            BigInt(786432),
+                            GAS_LIMIT_PER_BLOCK,
                           "standard",
                           { maximumFractionDigits: 2 }
                         )}

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -79,7 +79,7 @@ const Block: NextPage = function () {
         fields={
           blockData
             ? [
-                { name: "Block Height", value: formatNumber(blockData.number) },
+                { name: "Block Height", value: blockData.number },
                 { name: "Hash", value: blockData.hash },
                 {
                   name: "Timestamp",
@@ -96,7 +96,7 @@ const Block: NextPage = function () {
                       href={buildSlotExternalUrl(blockData.slot)}
                       isExternal
                     >
-                      {formatNumber(blockData.slot)}
+                      {blockData.slot}
                     </Link>
                   ),
                 },
@@ -106,11 +106,32 @@ const Block: NextPage = function () {
                 },
                 {
                   name: "Blob Gas Price",
-                  value: formatWei(blockData.blobGasPrice),
+                  value: (
+                    <div>
+                      {formatWei(blockData.blobGasPrice, { toUnit: "ether" })}
+                      <span className="ml-1 text-gray-500">
+                        ({formatWei(blockData.blobGasPrice)})
+                      </span>
+                    </div>
+                  ),
                 },
                 {
                   name: "Total Blob Gas Used",
-                  value: formatNumber(blockData.blobGasUsed),
+                  value: (
+                    <div>
+                      {formatNumber(blockData.blobGasUsed)}
+                      <span className="ml-1 text-gray-500">
+                        (
+                        {formatNumber(
+                          (blockData.blobGasUsed * BigInt(100)) /
+                            BigInt(786432),
+                          "standard",
+                          { maximumFractionDigits: 2 }
+                        )}
+                        %)
+                      </span>
+                    </div>
+                  ),
                 },
                 {
                   name: "Total Blob As Calldata Gas",

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -23,6 +23,7 @@ import {
   calculatePercentage,
   BLOB_GAS_LIMIT_PER_BLOCK,
   performDiv,
+  pluralize,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -113,7 +114,8 @@ const Block: NextPage = function () {
                     <div>
                       {formatBytes(totalBlobSize)}
                       <span className="ml-1 text-gray-500">
-                        ({formatNumber(totalBlobSize / GAS_PER_BLOB)} blobs)
+                        ({formatNumber(totalBlobSize / GAS_PER_BLOB)}{" "}
+                        {pluralize("blob", totalBlobSize / GAS_PER_BLOB)})
                       </span>
                     </div>
                   ),
@@ -160,7 +162,8 @@ const Block: NextPage = function () {
                     <div>
                       {formatNumber(MAX_BLOBS_PER_BLOCK)}
                       <span className="ml-1 text-gray-500">
-                        ({formatNumber(MAX_BLOBS_PER_BLOCK)} blobs per block)
+                        ({formatNumber(MAX_BLOBS_PER_BLOCK)}{" "}
+                        {pluralize("blob", MAX_BLOBS_PER_BLOCK)} per block)
                       </span>
                     </div>
                   ),

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -16,6 +16,7 @@ import {
   formatNumber,
   formatTimestamp,
   formatWei,
+  gasTarget,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -116,7 +117,7 @@ const Block: NextPage = function () {
                   ),
                 },
                 {
-                  name: "Total Blob Gas Used",
+                  name: "Blob Gas Used",
                   value: (
                     <div>
                       {formatNumber(blockData.blobGasUsed)}
@@ -129,12 +130,24 @@ const Block: NextPage = function () {
                           { maximumFractionDigits: 2 }
                         )}
                         %)
+                      </span>{" "}
+                      {gasTarget(blockData.blobGasUsed)}
+                    </div>
+                  ),
+                },
+                {
+                  name: "Blob Gas Limit",
+                  value: (
+                    <div>
+                      {formatNumber(786432)}
+                      <span className="ml-1 text-gray-500">
+                        (6 blobs per block)
                       </span>
                     </div>
                   ),
                 },
                 {
-                  name: "Total Blob As Calldata Gas",
+                  name: "Blob As Calldata Gas",
                   value: (
                     <div>
                       {formatNumber(blockData.blobAsCalldataGasUsed)}

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -17,6 +17,7 @@ import {
   formatTimestamp,
   formatWei,
   gasTarget,
+  GAS_PER_BLOB,
 } from "~/utils";
 
 function performBlockQuery(router: NextRouter) {
@@ -102,8 +103,16 @@ const Block: NextPage = function () {
                   ),
                 },
                 {
-                  name: "Total Blob Size",
-                  value: formatBytes(totalBlobSize),
+                  name: "Blob Size",
+                  value: (
+                    <div>
+                      {formatBytes(totalBlobSize)}
+                      <span className="ml-1 text-gray-500">
+                        ({formatNumber(BigInt(totalBlobSize) / GAS_PER_BLOB)}{" "}
+                        blobs)
+                      </span>
+                    </div>
+                  ),
                 },
                 {
                   name: "Blob Gas Price",

--- a/apps/web/src/pages/tx/[hash].tsx
+++ b/apps/web/src/pages/tx/[hash].tsx
@@ -17,6 +17,7 @@ import {
   formatWei,
   formatBytes,
   formatNumber,
+  performDiv,
 } from "~/utils";
 
 const Tx: NextPage = () => {
@@ -39,12 +40,16 @@ const Tx: NextPage = () => {
             block: {
               ...txData_.block,
               blobGasPrice: BigInt(txData_.block.blobGasPrice),
-              excessBlobGas: BigInt(txData_.block.excessBlobGas),
+
+              Gas: BigInt(txData_.block.excessBlobGas),
             },
           }
         : undefined,
     [txData_]
   );
+
+  console.log("here");
+  console.log(txData?.blobAsCalldataGasUsed);
 
   if (error) {
     return (
@@ -62,7 +67,7 @@ const Tx: NextPage = () => {
   const sortedBlobs = txData?.blobs.sort((a, b) => a.index - b.index);
   const blobGasPrice = txData?.block.blobGasPrice ?? BigInt(0);
   const blobGasUsed = txData
-    ? BigInt(txData.blobs.length) * GAS_PER_BLOB
+    ? BigInt(txData.blobs.length) * BigInt(GAS_PER_BLOB)
     : BigInt(0);
   const totalBlobSize =
     txData?.blobs.reduce((acc, { blob }) => acc + blob.size, 0) ?? 0;
@@ -150,7 +155,7 @@ const Tx: NextPage = () => {
                       {formatNumber(txData.blobAsCalldataGasUsed)} (
                       <strong>
                         {formatNumber(
-                          txData.blobAsCalldataGasUsed / blobGasUsed,
+                          performDiv(txData.blobAsCalldataGasUsed, blobGasUsed),
                           "standard",
                           {
                             maximumFractionDigits: 2,

--- a/apps/web/src/pages/tx/[hash].tsx
+++ b/apps/web/src/pages/tx/[hash].tsx
@@ -82,7 +82,7 @@ const Tx: NextPage = () => {
                   name: "Block",
                   value: (
                     <Link href={buildBlockRoute(txData.blockNumber)}>
-                      {formatNumber(txData.blockNumber)}
+                      {txData.blockNumber}
                     </Link>
                   ),
                 },

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -60,18 +60,15 @@ export function convertWei(
   }
 }
 
-export function gasTarget(blobGasUsed: bigint): string {
+export function calculateBlobGasTarget(blobGasUsed: bigint) {
   const blobsInBlock = blobGasUsed / GAS_PER_BLOB;
-  const targetPercent =
+  const targetPercentage =
     blobsInBlock < TARGET_BLOBS_PER_BLOCK
-      ? `${(blobsInBlock * BigInt(100)) / TARGET_BLOBS_PER_BLOCK}`
-      : `${
-          ((blobsInBlock - TARGET_BLOBS_PER_BLOCK) * BigInt(100)) /
-          TARGET_BLOBS_PER_BLOCK
-        }`;
-  const sign = blobsInBlock < TARGET_BLOBS_PER_BLOCK ? "-" : "+";
-  const percentStr = `${sign}${targetPercent}`;
-  return `${percentStr}% Blob Gas Target`;
+      ? (blobsInBlock * BigInt(100)) / TARGET_BLOBS_PER_BLOCK
+      : ((blobsInBlock - TARGET_BLOBS_PER_BLOCK) * BigInt(100)) /
+        TARGET_BLOBS_PER_BLOCK;
+
+  return targetPercentage;
 }
 
 export function formatWei(

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -7,7 +7,7 @@ const TARGET_BLOBS_PER_BLOCK = BigInt(3);
 export const MAX_BLOBS_PER_BLOCK = BigInt(6);
 export const GAS_LIMIT_PER_BLOCK = GAS_PER_BLOB * MAX_BLOBS_PER_BLOCK;
 
-export type EtherUnit = "wei" | "gwei" | "ether";
+export type EtherUnit = "wei" | "Gwei" | "ether";
 
 function formatWithDecimal(str: string, positionFromEnd: number): string {
   const [integerPart = "", decimalPart = ""] = str.split(".");
@@ -45,7 +45,7 @@ export type FormatWeiOptions = {
 
 export function convertWei(
   weiAmount: string | number,
-  toUnit: EtherUnit = "gwei"
+  toUnit: EtherUnit = "Gwei"
 ) {
   const weiAmount_ =
     typeof weiAmount === "number" ? weiAmount.toString() : weiAmount;
@@ -53,7 +53,7 @@ export function convertWei(
   switch (toUnit) {
     case "wei":
       return weiAmount_;
-    case "gwei":
+    case "Gwei":
       return formatWithDecimal(weiAmount_, 9);
     case "ether":
       return formatWithDecimal(weiAmount_, 18);
@@ -77,7 +77,7 @@ export function gasTarget(blobGasUsed: bigint): string {
 export function formatWei(
   weiAmount: bigint | number,
   {
-    toUnit = "gwei",
+    toUnit = "Gwei",
     displayUnit = true,
     compact = false,
   }: Partial<FormatWeiOptions> = {}

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -57,6 +57,21 @@ export function convertWei(
   }
 }
 
+export function gasTarget(blobGasUsed: bigint): string {
+  const blobsInBlock = blobGasUsed / BigInt(128 * 1024);
+  const targetBlobsPerBlock = BigInt(3);
+  const targetPercent =
+    blobsInBlock < targetBlobsPerBlock
+      ? `${(blobsInBlock * BigInt(100)) / targetBlobsPerBlock}`
+      : `${
+          ((blobsInBlock - targetBlobsPerBlock) * BigInt(100)) /
+          targetBlobsPerBlock
+        }`;
+  const sign = blobsInBlock < targetBlobsPerBlock ? "-" : "+";
+  const percentStr = `${sign}${targetPercent}`;
+  return `${percentStr}% Blob Gas Target`;
+}
+
 export function formatWei(
   weiAmount: bigint | number,
   {

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -58,7 +58,7 @@ export function convertWei(
 }
 
 export function gasTarget(blobGasUsed: bigint): string {
-  const blobsInBlock = blobGasUsed / BigInt(128 * 1024);
+  const blobsInBlock = blobGasUsed / GAS_PER_BLOB;
   const targetBlobsPerBlock = BigInt(3);
   const targetPercent =
     blobsInBlock < targetBlobsPerBlock

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -3,6 +3,9 @@ import { formatNumber } from "./number";
 const MIN_BLOB_GASPRICE = BigInt(1);
 const BLOB_GASPRICE_UPDATE_FRACTION = BigInt(3_338_477);
 export const GAS_PER_BLOB = BigInt(2 ** 17); // 131_072
+const TARGET_BLOBS_PER_BLOCK = BigInt(3);
+export const MAX_BLOBS_PER_BLOCK = BigInt(6);
+export const GAS_LIMIT_PER_BLOCK = GAS_PER_BLOB * MAX_BLOBS_PER_BLOCK;
 
 export type EtherUnit = "wei" | "gwei" | "ether";
 
@@ -59,15 +62,14 @@ export function convertWei(
 
 export function gasTarget(blobGasUsed: bigint): string {
   const blobsInBlock = blobGasUsed / GAS_PER_BLOB;
-  const targetBlobsPerBlock = BigInt(3);
   const targetPercent =
-    blobsInBlock < targetBlobsPerBlock
-      ? `${(blobsInBlock * BigInt(100)) / targetBlobsPerBlock}`
+    blobsInBlock < TARGET_BLOBS_PER_BLOCK
+      ? `${(blobsInBlock * BigInt(100)) / TARGET_BLOBS_PER_BLOCK}`
       : `${
-          ((blobsInBlock - targetBlobsPerBlock) * BigInt(100)) /
-          targetBlobsPerBlock
+          ((blobsInBlock - TARGET_BLOBS_PER_BLOCK) * BigInt(100)) /
+          TARGET_BLOBS_PER_BLOCK
         }`;
-  const sign = blobsInBlock < targetBlobsPerBlock ? "-" : "+";
+  const sign = blobsInBlock < TARGET_BLOBS_PER_BLOCK ? "-" : "+";
   const percentStr = `${sign}${targetPercent}`;
   return `${percentStr}% Blob Gas Target`;
 }

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -1,5 +1,3 @@
-import type { Decimal } from "@blobscan/api";
-
 import { calculatePercentage, formatNumber, performDiv } from "./number";
 
 export const GAS_PER_BLOB = 131_072; // 2 ** 17
@@ -75,7 +73,7 @@ export function calculateBlobGasTarget(blobGasUsed: bigint) {
 }
 
 export function formatWei(
-  weiAmount: bigint | number | Decimal,
+  weiAmount: bigint | number,
   {
     toUnit = "Gwei",
     displayUnit = true,

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -84,7 +84,7 @@ export function formatWei(
     compact ? "compact" : "standard",
     {
       // Display up to 9 decimal digits for small wei amounts
-      maximumFractionDigits: weiAmountStr.length < 9 ? 9 : 3,
+      maximumFractionDigits: weiAmountStr.length < 12 ? 18 : 3,
     }
   );
 

--- a/apps/web/src/utils/number.ts
+++ b/apps/web/src/utils/number.ts
@@ -1,6 +1,22 @@
 import type { Options } from "pretty-bytes";
 import prettyBytes from "pretty-bytes";
 
+type FormatMode = "compact" | "standard";
+
+export type BigIntLike = bigint | number | string;
+
+const NUMBER_FORMAT: Record<FormatMode, Intl.NumberFormatOptions> = {
+  compact: {
+    notation: "compact",
+    maximumFractionDigits: 2,
+  },
+  standard: {
+    notation: "standard",
+    compactDisplay: "long",
+    maximumFractionDigits: 3,
+  },
+};
+
 export function formatBytes(bytes: number | bigint, opts: Options = {}) {
   const bytes_ = typeof bytes === "bigint" ? Number(bytes) : bytes;
 
@@ -18,41 +34,43 @@ export function abbreviateNumber(value: number | string): string {
   }).format(Number(value));
 }
 
-type FormatMode = "compact" | "standard";
+export function performDiv(a: BigIntLike, b: BigIntLike, precision = 16) {
+  const a_ = BigInt(a);
+  const b_ = BigInt(b);
 
-const NUMBER_FORMAT: Record<FormatMode, Intl.NumberFormatOptions> = {
-  compact: {
-    notation: "compact",
-    maximumFractionDigits: 2,
-  },
-  standard: {
-    notation: "standard",
-    compactDisplay: "long",
-    maximumFractionDigits: 3,
-  },
-};
+  if (b_ === BigInt(0)) {
+    throw new Error("Division by zero");
+  }
+
+  const scaleFactor = 10 ** precision;
+  const scaledResult = (a_ * BigInt(scaleFactor)) / b_;
+
+  return Number(scaledResult) / scaleFactor;
+}
+
 export function formatNumber(
   x: number | string | bigint,
   mode: "compact" | "standard" = "standard",
   opts: Intl.NumberFormatOptions = {}
 ): string {
-  // return Number(x).toLocaleString(undefined, opts);
-
   return Intl.NumberFormat("en-US", { ...NUMBER_FORMAT[mode], ...opts }).format(
     Number(x)
   );
 }
 
 export function calculatePercentage(
-  numerator: bigint,
-  denominator: bigint,
-  opts?: { returnComplement: boolean }
+  numerator: BigIntLike,
+  denominator: BigIntLike,
+  opts?: Partial<{ returnComplement: boolean }>
 ): number {
-  if (denominator === BigInt(0)) {
+  const num = BigInt(numerator);
+  const denom = BigInt(denominator);
+
+  if (denom === BigInt(0)) {
     return Number(0);
   }
 
-  const pct = (Number((numerator * BigInt(100)) / denominator) / 100) * 100;
+  const pct = performDiv(num, denom) * 100;
 
   if (opts?.returnComplement) {
     return 100 - pct;

--- a/apps/web/src/utils/text.ts
+++ b/apps/web/src/utils/text.ts
@@ -5,9 +5,14 @@ export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+export function pluralize(word: string, count: number) {
+  return count === 1 ? word : `${word}s`;
+}
 
 export function hexStringToUtf8(hexString: string): string {
-  const byteArray = hexString.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16));
+  const byteArray = hexString
+    .match(/.{1,2}/g)
+    ?.map((byte) => parseInt(byte, 16));
 
   if (!byteArray) {
     throw new Error("Invalid hexadecimal string");

--- a/packages/config/tailwind/colors.ts
+++ b/packages/config/tailwind/colors.ts
@@ -85,10 +85,7 @@ export const baseColors = {
   },
 };
 
-const primary = baseColors.primary;
-const coolGray = baseColors.coolGray;
-const warmGray = baseColors.warmGray;
-const shades = baseColors.shades;
+const { coolGray, primary, shades, success, error, warmGray } = baseColors;
 
 export const semanticColors = {
   accent: {
@@ -122,6 +119,10 @@ export const semanticColors = {
   contentSecondary: {
     light: warmGray[600],
     dark: coolGray[700],
+  },
+  contentTertiary: {
+    light: warmGray[400],
+    dark: coolGray[400],
   },
   contentDisabled: {
     light: warmGray[400],
@@ -166,6 +167,14 @@ export const semanticColors = {
   link: {
     light: primary[700],
     dark: primary[400],
+  },
+  negative: {
+    light: error[500],
+    dark: error[400],
+  },
+  positive: {
+    light: success[500],
+    dark: success[400],
   },
   surface: {
     light: shades["00"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,9 +217,6 @@ importers:
       '@blobscan/dayjs':
         specifier: ^0.0.1
         version: link:../../packages/dayjs
-      '@blobscan/db':
-        specifier: ^0.0.1
-        version: link:../../packages/db
       '@blobscan/open-telemetry':
         specifier: ^0.0.1
         version: link:../../packages/open-telemetry


### PR DESCRIPTION
Fixes https://github.com/Blobscan/blobscan/issues/133

Changes:

* Do not format **Block and Slot number** with commas, as in other block explorers. It also makes it easier to copy-paste.
* **Blob Gas Price** now is shown in ether and gwei for easier conversions
* **Removed 'Total' from metric names**
* **Blob Gas Used** now shows the percentage of blob space used and target blob gas (reminder: maximum blobs per block is 6, while target is 3, similar to how the gas fee work)
* Show number of blobs next to **Blob Size**
* Show **Blob Gas Limit**


**BEFORE THIS PR:**

![image](https://github.com/Blobscan/blobscan/assets/73274/5405d590-d6da-4e50-8852-032e48641d71)

**AFTER THIS PR:**

![image](https://github.com/Blobscan/blobscan/assets/73274/a3ce9e13-b4a3-4d8c-aaff-3e9d2eb725a9)
