### PR TITLE
fix(web): details view improvements

### DIFF
--- a/apps/web/src/components/Cards/Card.tsx
+++ b/apps/web/src/components/Cards/Card.tsx
@@ -22,10 +22,11 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(function (
       className={cn(
         `
         w-full 
-        rounded-lg
-        border 
-        border-surface-light
-        bg-surface-light  
+        overflow-hidden
+        break-words
+        rounded-lg 
+        border-surface-light  
+        bg-surface-light
         dark:border-surface-dark
         dark:bg-surface-dark
         ${className}

--- a/apps/web/src/components/Displays/BlobGasUsageDisplay.tsx
+++ b/apps/web/src/components/Displays/BlobGasUsageDisplay.tsx
@@ -7,7 +7,7 @@ import {
   calculatePercentage,
   formatNumber,
 } from "~/utils";
-import { PercentageBar } from "./PercentageBar";
+import { PercentageBar } from "../PercentageBar";
 
 type BlobGasUsageDisplayProps = {
   blobGasUsed: bigint;

--- a/apps/web/src/components/Displays/EtherUnitDisplay.tsx
+++ b/apps/web/src/components/Displays/EtherUnitDisplay.tsx
@@ -1,0 +1,20 @@
+import type { FC } from "react";
+
+import { formatWei } from "~/utils";
+
+type EtherUnitDisplayProps = {
+  amount: bigint | number;
+};
+
+export const EtherUnitDisplay: FC<EtherUnitDisplayProps> = function ({
+  amount,
+}) {
+  return (
+    <div>
+      {formatWei(amount, { toUnit: "ether" })}
+      <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
+        ({formatWei(amount)})
+      </span>
+    </div>
+  );
+};

--- a/apps/web/src/components/InfoGrid.tsx
+++ b/apps/web/src/components/InfoGrid.tsx
@@ -14,9 +14,9 @@ export const InfoGrid: React.FC<InfoGridProps> = function ({ fields }) {
   const breakpoint = useBreakpoint();
   const isCompact = breakpoint === "default";
   const headerWidth = isCompact ? "100%" : "55%";
-  const valueWidth = isCompact ? "100%" : "70%";
+  const valueWidth = isCompact ? "100%" : "50%";
   const skeletonsLength = isCompact ? 4 : 7;
-  const skeletonHeight = isCompact ? 17 : 20;
+  const skeletonHeight = isCompact ? 15 : 15;
 
   return (
     <div className="grid w-full gap-3 md:grid-cols-4">

--- a/apps/web/src/components/InfoGrid.tsx
+++ b/apps/web/src/components/InfoGrid.tsx
@@ -4,21 +4,30 @@ import type { ReactNode } from "react";
 import "react-loading-skeleton/dist/skeleton.css";
 import Skeleton from "react-loading-skeleton";
 
+import { useBreakpoint } from "~/hooks/useBreakpoint";
+
 export type InfoGridProps = {
   fields?: { name: ReactNode; value: ReactNode }[];
 };
 
 export const InfoGrid: React.FC<InfoGridProps> = function ({ fields }) {
+  const breakpoint = useBreakpoint();
+  const isCompact = breakpoint === "default";
+  const headerWidth = isCompact ? "100%" : "55%";
+  const valueWidth = isCompact ? "100%" : "70%";
+  const skeletonsLength = isCompact ? 4 : 7;
+  const skeletonHeight = isCompact ? 17 : 20;
+
   return (
     <div className="grid w-full gap-3 md:grid-cols-4">
       {!fields
-        ? Array.from({ length: 4 }).map((_, i) => (
+        ? Array.from({ length: skeletonsLength }).map((_, i) => (
             <Fragment key={i}>
               <div>
-                <Skeleton width={180} />
+                <Skeleton width={headerWidth} height={skeletonHeight} />
               </div>
               <div className="col-span-3">
-                <Skeleton width={400} />
+                <Skeleton width={valueWidth} height={skeletonHeight} />
               </div>
             </Fragment>
           ))

--- a/apps/web/src/components/InfoGrid.tsx
+++ b/apps/web/src/components/InfoGrid.tsx
@@ -10,7 +10,7 @@ export type InfoGridProps = {
 
 export const InfoGrid: React.FC<InfoGridProps> = function ({ fields }) {
   return (
-    <div className="grid w-fit gap-3 md:grid-cols-4">
+    <div className="grid w-full gap-3 md:grid-cols-4">
       {!fields
         ? Array.from({ length: 4 }).map((_, i) => (
             <Fragment key={i}>
@@ -25,7 +25,9 @@ export const InfoGrid: React.FC<InfoGridProps> = function ({ fields }) {
         : fields.map(({ name, value }, i) => (
             <Fragment key={i}>
               <div className="font-semibold dark:text-coolGray-400">{name}</div>
-              <div className="col-span-3 truncate text-sm">{value}</div>
+              <div className="col-span-3 overflow-hidden break-words text-sm">
+                {value}
+              </div>
             </Fragment>
           ))}
     </div>

--- a/apps/web/src/components/Layouts/DetailsLayout.tsx
+++ b/apps/web/src/components/Layouts/DetailsLayout.tsx
@@ -23,7 +23,7 @@ export const DetailsLayout: FC<DetailsLayoutProps> = function ({
       <Header>{header}</Header>
       <Card
         header={
-          <div className="flex flex-col justify-between gap-1 md:flex-row">
+          <div className="flex flex-row justify-between gap-1">
             <div className="truncate">Overview</div>
             {externalLink && (
               <div className="text-sm font-normal">

--- a/apps/web/src/hooks/useBreakpoint.ts
+++ b/apps/web/src/hooks/useBreakpoint.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+
+export type Breakpoint = "2xl" | "xl" | "lg" | "md" | "sm" | "default";
+
+function getActiveBreakpoint(): Breakpoint {
+  if (window.matchMedia("(min-width: 1536px)").matches) {
+    return "2xl";
+  } else if (window.matchMedia("(min-width: 1280px)").matches) {
+    return "xl";
+  } else if (window.matchMedia("(min-width: 1024px)").matches) {
+    return "lg";
+  } else if (window.matchMedia("(min-width: 768px)").matches) {
+    return "md";
+  } else if (window.matchMedia("(min-width: 640px)").matches) {
+    return "sm";
+  }
+
+  return "default";
+}
+
+export function useBreakpoint() {
+  const [currentBreakpoint, setCurrentBreakpoint] = useState<Breakpoint>(
+    getActiveBreakpoint()
+  );
+  const breakpointRef = useRef<Breakpoint>();
+
+  useEffect(() => {
+    function trackResize() {
+      breakpointRef.current = getActiveBreakpoint();
+      if (breakpointRef.current !== currentBreakpoint) {
+        setCurrentBreakpoint(breakpointRef.current);
+      }
+    }
+
+    window.addEventListener("resize", trackResize);
+
+    return () => {
+      console.log("going out ");
+      window.removeEventListener("resize", trackResize);
+    };
+  });
+
+  return currentBreakpoint;
+}

--- a/apps/web/src/hooks/useBreakpoint.ts
+++ b/apps/web/src/hooks/useBreakpoint.ts
@@ -35,7 +35,6 @@ export function useBreakpoint() {
     window.addEventListener("resize", trackResize);
 
     return () => {
-      console.log("going out ");
       window.removeEventListener("resize", trackResize);
     };
   });

--- a/apps/web/src/pages/block/[id].tsx
+++ b/apps/web/src/pages/block/[id].tsx
@@ -4,9 +4,10 @@ import NextError from "next/error";
 import { useRouter } from "next/router";
 import type { NextRouter } from "next/router";
 
-import { BlobGasUsageDisplay } from "~/components/BlobGasUsageDisplay";
 import { Card } from "~/components/Cards/Card";
 import { BlobTransactionCard } from "~/components/Cards/SurfaceCards/BlobTransactionCard";
+import { BlobGasUsageDisplay } from "~/components/Displays/BlobGasUsageDisplay";
+import { EtherUnitDisplay } from "~/components/Displays/EtherUnitDisplay";
 import { DetailsLayout } from "~/components/Layouts/DetailsLayout";
 import { Link } from "~/components/Link";
 import { api } from "~/api-client";
@@ -16,7 +17,6 @@ import {
   formatBytes,
   formatNumber,
   formatTimestamp,
-  formatWei,
   GAS_PER_BLOB,
   MAX_BLOBS_PER_BLOCK,
   performDiv,
@@ -119,14 +119,7 @@ const Block: NextPage = function () {
                 },
                 {
                   name: "Blob Gas Price",
-                  value: (
-                    <div>
-                      {formatWei(blockData.blobGasPrice, { toUnit: "ether" })}
-                      <span className="ml-1 text-contentTertiary-light dark:text-contentTertiary-dark">
-                        ({formatWei(blockData.blobGasPrice)})
-                      </span>
-                    </div>
-                  ),
+                  value: <EtherUnitDisplay amount={blockData.blobGasPrice} />,
                 },
                 {
                   name: "Blob Gas Used",

--- a/apps/web/src/pages/tx/[hash].tsx
+++ b/apps/web/src/pages/tx/[hash].tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 
 import { Card } from "~/components/Cards/Card";
 import { BlobCard } from "~/components/Cards/SurfaceCards/BlobCard";
+import { EtherUnitDisplay } from "~/components/Displays/EtherUnitDisplay";
 import { DetailsLayout } from "~/components/Layouts/DetailsLayout";
 import { Link } from "~/components/Link";
 import { api } from "~/api-client";
@@ -14,7 +15,6 @@ import {
   buildTransactionExternalUrl,
   formatTimestamp,
   GAS_PER_BLOB,
-  formatWei,
   formatBytes,
   formatNumber,
   performDiv,
@@ -47,9 +47,6 @@ const Tx: NextPage = () => {
         : undefined,
     [txData_]
   );
-
-  console.log("here");
-  console.log(txData?.blobAsCalldataGasUsed);
 
   if (error) {
     return (
@@ -122,27 +119,27 @@ const Tx: NextPage = () => {
                 {
                   name: "Blob Fee",
                   value: (
-                    <div className="flex gap-4">
-                      <div>
-                        <span className="mr-1 text-contentSecondary-light dark:text-contentSecondary-dark">
+                    <div className="flex flex-col gap-4">
+                      <div className="flex gap-1">
+                        <div className="mr-1 text-contentSecondary-light dark:text-contentSecondary-dark">
                           Base:
-                        </span>
-                        {formatWei(blobGasPrice * BigInt(blobGasUsed))}
+                        </div>
+                        <EtherUnitDisplay amount={blobGasPrice * blobGasUsed} />
                       </div>
-                      <div>
-                        <span className="mr-1 text-contentSecondary-light dark:text-contentSecondary-dark">
+                      <div className=" flex gap-1">
+                        <div className="mr-1 text-contentSecondary-light dark:text-contentSecondary-dark">
                           Max:
-                        </span>
-                        {formatWei(
-                          txData.maxFeePerBlobGas * BigInt(blobGasUsed)
-                        )}
+                        </div>
+                        <EtherUnitDisplay
+                          amount={txData.maxFeePerBlobGas * blobGasUsed}
+                        />
                       </div>
                     </div>
                   ),
                 },
                 {
                   name: "Blob Gas Price",
-                  value: formatWei(blobGasPrice),
+                  value: <EtherUnitDisplay amount={blobGasPrice} />,
                 },
                 {
                   name: "Blob Gas Used",
@@ -152,17 +149,23 @@ const Tx: NextPage = () => {
                   name: "Blob As Calldata Gas",
                   value: (
                     <div>
-                      {formatNumber(txData.blobAsCalldataGasUsed)} (
-                      <strong>
-                        {formatNumber(
-                          performDiv(txData.blobAsCalldataGasUsed, blobGasUsed),
-                          "standard",
-                          {
-                            maximumFractionDigits: 2,
-                          }
-                        )}
-                      </strong>{" "}
-                      times more expensive)
+                      {formatNumber(txData.blobAsCalldataGasUsed)}{" "}
+                      <span className="text-contentTertiary-light dark:text-contentTertiary-dark">
+                        (
+                        <strong>
+                          {formatNumber(
+                            performDiv(
+                              txData.blobAsCalldataGasUsed,
+                              blobGasUsed
+                            ),
+                            "standard",
+                            {
+                              maximumFractionDigits: 2,
+                            }
+                          )}
+                        </strong>{" "}
+                        times more expensive)
+                      </span>
                     </div>
                   ),
                 },

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -86,7 +86,6 @@ export function formatWei(
       ? Math.floor(weiAmount).toString()
       : weiAmount.toString();
   let formattedAmount = convertWei(weiAmountStr, toUnit);
-
   const fractionDigits = formattedAmount.split(".")[1];
 
   // Use exponential notation for large fractional digits
@@ -98,10 +97,10 @@ export function formatWei(
     formattedAmount,
     compact ? "compact" : "standard",
     {
-      // Display up to 9 decimal digits for small wei amounts
-      maximumFractionDigits: weiAmountStr.length < 12 ? 18 : 3,
+      maximumFractionDigits: compact ? 5 : 18,
     }
   );
+  console.log(formattedAmount);
 
   return `${formattedAmount}${displayUnit ? ` ${toUnit}` : ""}`;
 }

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -100,7 +100,6 @@ export function formatWei(
       maximumFractionDigits: compact ? 5 : 18,
     }
   );
-  console.log(formattedAmount);
 
   return `${formattedAmount}${displayUnit ? ` ${toUnit}` : ""}`;
 }


### PR DESCRIPTION
It adds the following changes to the details pages:

1. Improve ether unit fields by displaying both `ether` and `gwei` amounts.
2. Polish skeleton loading display and fix overflowing problem on mobile view