### PR TITLE
chore: reintegrate Prisma migration execution into vercel build flow

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "cd ../../ && prisma generate --schema packages/db/prisma/schema.prisma && turbo run build --filter=web",
+  "buildCommand": "cd ../../ && prisma generate --schema packages/db/prisma/schema.prisma && prisma migrate deploy --schema packages/db/prisma/schema.prisma && turbo run build --filter=web",
   "installCommand": "pnpm install --store=node_modules/.pnpm-store",
   "framework": "nextjs"
 }


### PR DESCRIPTION
We can reintegrate it, as we can now safely apply Prisma migrations to PRs with a specific database instance set up for Vercel's preview environment.