### PR TITLE
feat(web): add back navigation from blob to transactions

### DIFF
--- a/.changeset/blue-geese-teach.md
+++ b/.changeset/blue-geese-teach.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": minor
+---
+
+Enhanced the `getByBlobId` procedure to include related transactions and blocks in the blob response

--- a/.changeset/flat-eagles-fail.md
+++ b/.changeset/flat-eagles-fail.md
@@ -1,0 +1,6 @@
+---
+"@blobscan/api": minor
+"@blobscan/web": minor
+---
+
+Added support for back navigation from blob to transactions page

--- a/.changeset/flat-eagles-fail.md
+++ b/.changeset/flat-eagles-fail.md
@@ -1,6 +1,5 @@
 ---
-"@blobscan/api": minor
 "@blobscan/web": minor
 ---
 
-Added support for back navigation from blob to transactions page
+Enhanced navigation from the blob details page, enabling direct links back to associated transactions and blocks

--- a/apps/web/src/pages/blob/[hash].tsx
+++ b/apps/web/src/pages/blob/[hash].tsx
@@ -11,8 +11,9 @@ import { Dropdown } from "~/components/Dropdown";
 import { ExpandableContent } from "~/components/ExpandableContent";
 import type { DetailsLayoutProps } from "~/components/Layouts/DetailsLayout";
 import { DetailsLayout } from "~/components/Layouts/DetailsLayout";
+import { Link } from "~/components/Link";
 import { api } from "~/api-client";
-import { formatBytes, hexStringToUtf8 } from "~/utils";
+import { buildTransactionRoute, formatBytes, hexStringToUtf8 } from "~/utils";
 
 type BlobViewMode = "Original" | "UTF-8";
 
@@ -36,7 +37,7 @@ const Blob: NextPage = function () {
     data: blob,
     error,
     isLoading,
-  } = api.blob.getByBlobId.useQuery(
+  } = api.blob.getByBlobIdFull.useQuery(
     {
       id: versionedHash,
     },
@@ -100,6 +101,19 @@ const Blob: NextPage = function () {
         value: swarmHash,
       });
     }
+
+    detailsFields.push({
+      name: "Transactions",
+      value: (
+        <div className="flex items-center gap-2">
+          {blob.transactions.map(({ txHash }) => (
+            <Link key={txHash} href={buildTransactionRoute(txHash)}>
+              {txHash.slice(0, 20)}...
+            </Link>
+          ))}
+        </div>
+      ),
+    });
   }
 
   return (

--- a/apps/web/src/pages/blob/[hash].tsx
+++ b/apps/web/src/pages/blob/[hash].tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import type { NextPage } from "next";
 import NextError from "next/error";
 import { useRouter } from "next/router";
@@ -13,7 +13,12 @@ import type { DetailsLayoutProps } from "~/components/Layouts/DetailsLayout";
 import { DetailsLayout } from "~/components/Layouts/DetailsLayout";
 import { Link } from "~/components/Link";
 import { api } from "~/api-client";
-import { buildTransactionRoute, formatBytes, hexStringToUtf8 } from "~/utils";
+import {
+  buildBlockRoute,
+  buildTransactionRoute,
+  formatBytes,
+  hexStringToUtf8,
+} from "~/utils";
 
 type BlobViewMode = "Original" | "UTF-8";
 
@@ -45,6 +50,7 @@ const Blob: NextPage = function () {
       enabled: router.isReady,
     }
   );
+
   const [selectedBlobViewMode, setSelectedBlobViewMode] =
     useState<BlobViewMode>("Original");
   const [formattedData, formattedDataErr] = useMemo(() => {
@@ -103,13 +109,24 @@ const Blob: NextPage = function () {
     }
 
     detailsFields.push({
-      name: "Transactions",
+      name: "Transactions and Blocks",
       value: (
-        <div className="flex items-center gap-2">
-          {blob.transactions.map(({ txHash }) => (
-            <Link key={txHash} href={buildTransactionRoute(txHash)}>
-              {txHash.slice(0, 20)}...
-            </Link>
+        <div className="grid w-full grid-cols-3 gap-y-3 md:grid-cols-3">
+          {blob.transactionsWithBlocks.map(({ txHash, blockNumber }) => (
+            <Fragment key={`${txHash}-${blockNumber}`}>
+              <div className="col-span-2 flex gap-1 md:col-span-2">
+                <div className="text-contentSecondary-light dark:text-contentSecondary-dark">
+                  Tx{" "}
+                </div>
+                <Link href={buildTransactionRoute(txHash)}>{txHash}</Link>
+              </div>
+              <div className="flex gap-1">
+                <div className="text-contentSecondary-light dark:text-contentSecondary-dark">
+                  Block{" "}
+                </div>
+                <Link href={buildBlockRoute(blockNumber)}>{blockNumber}</Link>
+              </div>
+            </Fragment>
           ))}
         </div>
       ),
@@ -122,7 +139,6 @@ const Blob: NextPage = function () {
         header="Blob Details"
         fields={blob ? detailsFields : undefined}
       />
-
       <Card
         header={
           <div className="flex items-center justify-between">

--- a/apps/web/src/types/routers.ts
+++ b/apps/web/src/types/routers.ts
@@ -10,7 +10,7 @@ export type AllTransactions = RouterOutputs["tx"]["getAllFull"];
 
 export type AllBlobs = RouterOutputs["blob"]["getAll"];
 
-export type Blob = RouterOutputs["blob"]["getByBlobId"];
+export type Blob = RouterOutputs["blob"]["getByBlobIdFull"];
 
 export type DailyBlobStats = RouterOutputs["stats"]["getBlobDailyStats"];
 

--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -103,3 +103,7 @@ export function formatWei(
 
   return `${formattedAmount}${displayUnit ? ` ${toUnit}` : ""}`;
 }
+
+export function shortenAddress(address: string, length = 4): string {
+  return `${address.slice(0, length)}…${address.slice(-length)}`;
+}

--- a/packages/api/src/routers/blob/getByBlobId.schema.ts
+++ b/packages/api/src/routers/blob/getByBlobId.schema.ts
@@ -1,4 +1,3 @@
-import { $Enums } from "@blobscan/db";
 import { z } from "@blobscan/zod";
 
 export const getByBlobIdInputSchema = z.object({
@@ -10,15 +9,5 @@ export const getByBlobIdOutputSchema = z.object({
   commitment: z.string(),
   proof: z.string().or(z.null()),
   size: z.number(),
-  dataStorageReferences: z.array(
-    z.object({
-      blobStorage: z.enum([
-        $Enums.BlobStorage.GOOGLE,
-        $Enums.BlobStorage.POSTGRES,
-        $Enums.BlobStorage.SWARM,
-      ]),
-      dataReference: z.string(),
-    })
-  ),
   data: z.string(),
 });

--- a/packages/api/src/routers/blob/getByBlobIdFull.ts
+++ b/packages/api/src/routers/blob/getByBlobIdFull.ts
@@ -23,8 +23,18 @@ export const getByBlobIdFull = publicProcedure
           },
         },
         transactions: {
+          distinct: ["txHash"],
           select: {
-            txHash: true,
+            transaction: {
+              select: {
+                hash: true,
+                block: {
+                  select: {
+                    number: true,
+                  },
+                },
+              },
+            },
           },
         },
       },
@@ -70,8 +80,19 @@ export const getByBlobIdFull = publicProcedure
       });
     }
 
+    const { transactions, ...blobMetadata } = blob;
+    const transactionsWithBlocks = transactions.map(
+      ({
+        transaction: {
+          hash,
+          block: { number },
+        },
+      }) => ({ txHash: hash, blockNumber: number })
+    );
+
     return {
-      ...blob,
+      ...blobMetadata,
+      transactionsWithBlocks,
       data: blobData.data,
     };
   });

--- a/packages/api/src/routers/blob/getByBlobIdFull.ts
+++ b/packages/api/src/routers/blob/getByBlobIdFull.ts
@@ -3,23 +3,10 @@ import { TRPCError } from "@trpc/server";
 import type { BlobReference } from "@blobscan/blob-storage-manager";
 
 import { publicProcedure } from "../../procedures";
-import {
-  getByBlobIdInputSchema,
-  getByBlobIdOutputSchema,
-} from "./getByBlobId.schema";
+import { getByBlobIdInputSchema } from "./getByBlobId.schema";
 
-export const getByBlobId = publicProcedure
-  .meta({
-    openapi: {
-      method: "GET",
-      path: "/blobs/{id}",
-      tags: ["blobs"],
-      summary:
-        "retrieves blob details for given versioned hash or kzg commitment.",
-    },
-  })
+export const getByBlobIdFull = publicProcedure
   .input(getByBlobIdInputSchema)
-  .output(getByBlobIdOutputSchema)
   .query(async ({ ctx: { prisma, blobStorageManager }, input }) => {
     const { id } = input;
 
@@ -33,6 +20,11 @@ export const getByBlobId = publicProcedure
           select: {
             blobStorage: true,
             dataReference: true,
+          },
+        },
+        transactions: {
+          select: {
+            txHash: true,
           },
         },
       },
@@ -79,10 +71,7 @@ export const getByBlobId = publicProcedure
     }
 
     return {
-      versionedHash: blob.versionedHash,
-      commitment: blob.commitment,
-      proof: blob.proof,
-      size: blob.size,
+      ...blob,
       data: blobData.data,
     };
   });

--- a/packages/api/src/routers/blob/index.ts
+++ b/packages/api/src/routers/blob/index.ts
@@ -1,8 +1,10 @@
 import { t } from "../../trpc-client";
 import { getAll } from "./getAll";
 import { getByBlobId } from "./getByBlobId";
+import { getByBlobIdFull } from "./getByBlobIdFull";
 
 export const blobRouter = t.router({
   getAll,
   getByBlobId,
+  getByBlobIdFull,
 });

--- a/packages/api/test/__snapshots__/blob.test.ts.snap
+++ b/packages/api/test/__snapshots__/blob.test.ts.snap
@@ -1,10 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Blob router > 'getByBlobId' > should fail when getting a blob and the blob data is not available > [TRPCError: Failed to get blob from any of the storages: ] 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
-
 exports[`Blob router > 'getByBlobId' > should fail when getting a blob and the blob data is not available 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
-
-exports[`Blob router > 'getByBlobId' > should fail when trying to get a blob by a non-existent hash > [TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.] 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
 
 exports[`Blob router > 'getByBlobId' > should fail when trying to get a blob by a non-existent hash 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
 
@@ -28,11 +24,7 @@ exports[`Blob router > 'getByBlobId' > should get a blob by versioned hash 1`] =
 }
 `;
 
-exports[`Blob router > 'getByBlobIdFull' > should fail when getting a blob and the blob data is not available > [TRPCError: Failed to get blob from any of the storages: ] 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
-
 exports[`Blob router > 'getByBlobIdFull' > should fail when getting a blob and the blob data is not available 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
-
-exports[`Blob router > 'getByBlobIdFull' > should fail when trying to get a blob by a non-existent hash > [TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.] 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
 
 exports[`Blob router > 'getByBlobIdFull' > should fail when trying to get a blob by a non-existent hash 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
 
@@ -52,17 +44,13 @@ exports[`Blob router > 'getByBlobIdFull' > should get a blob by kzg commitment 1
   ],
   "proof": "proof004",
   "size": 1300,
-  "transactions": [
+  "transactionsWithBlocks": [
     {
+      "blockNumber": 1002,
       "txHash": "txHash004",
     },
     {
-      "txHash": "txHash015",
-    },
-    {
-      "txHash": "txHash015",
-    },
-    {
+      "blockNumber": 1007,
       "txHash": "txHash015",
     },
   ],
@@ -86,17 +74,13 @@ exports[`Blob router > 'getByBlobIdFull' > should get a blob by versioned hash 1
   ],
   "proof": "proof004",
   "size": 1300,
-  "transactions": [
+  "transactionsWithBlocks": [
     {
+      "blockNumber": 1002,
       "txHash": "txHash004",
     },
     {
-      "txHash": "txHash015",
-    },
-    {
-      "txHash": "txHash015",
-    },
-    {
+      "blockNumber": 1007,
       "txHash": "txHash015",
     },
   ],
@@ -136,44 +120,4 @@ exports[`Blob router > getAll > when getting paginated blob results > should ret
     "versionedHash": "blobHash001",
   },
 ]
-`;
-
-exports[`Blob router > getByBlobId > should get a blob by kzg commitment 1`] = `
-{
-  "commitment": "commitment004",
-  "data": "0xd76df869b71d79f835db7e39ebbf3d69b71d7e",
-  "dataStorageReferences": [
-    {
-      "blobStorage": "POSTGRES",
-      "dataReference": "blobHash004",
-    },
-    {
-      "blobStorage": "GOOGLE",
-      "dataReference": "7011893058/ob/Ha/sh/obHash004.txt",
-    },
-  ],
-  "proof": "proof004",
-  "size": 1300,
-  "versionedHash": "blobHash004",
-}
-`;
-
-exports[`Blob router > getByBlobId > should get a blob by versioned hash 1`] = `
-{
-  "commitment": "commitment004",
-  "data": "0xd76df869b71d79f835db7e39ebbf3d69b71d7e",
-  "dataStorageReferences": [
-    {
-      "blobStorage": "POSTGRES",
-      "dataReference": "blobHash004",
-    },
-    {
-      "blobStorage": "GOOGLE",
-      "dataReference": "7011893058/ob/Ha/sh/obHash004.txt",
-    },
-  ],
-  "proof": "proof004",
-  "size": 1300,
-  "versionedHash": "blobHash004",
-}
 `;

--- a/packages/api/test/__snapshots__/blob.test.ts.snap
+++ b/packages/api/test/__snapshots__/blob.test.ts.snap
@@ -2,7 +2,11 @@
 
 exports[`Blob router > 'getByBlobId' > should fail when getting a blob and the blob data is not available > [TRPCError: Failed to get blob from any of the storages: ] 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
 
+exports[`Blob router > 'getByBlobId' > should fail when getting a blob and the blob data is not available 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
+
 exports[`Blob router > 'getByBlobId' > should fail when trying to get a blob by a non-existent hash > [TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.] 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
+
+exports[`Blob router > 'getByBlobId' > should fail when trying to get a blob by a non-existent hash 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
 
 exports[`Blob router > 'getByBlobId' > should get a blob by kzg commitment 1`] = `
 {
@@ -26,7 +30,11 @@ exports[`Blob router > 'getByBlobId' > should get a blob by versioned hash 1`] =
 
 exports[`Blob router > 'getByBlobIdFull' > should fail when getting a blob and the blob data is not available > [TRPCError: Failed to get blob from any of the storages: ] 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
 
+exports[`Blob router > 'getByBlobIdFull' > should fail when getting a blob and the blob data is not available 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
+
 exports[`Blob router > 'getByBlobIdFull' > should fail when trying to get a blob by a non-existent hash > [TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.] 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
+
+exports[`Blob router > 'getByBlobIdFull' > should fail when trying to get a blob by a non-existent hash 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
 
 exports[`Blob router > 'getByBlobIdFull' > should get a blob by kzg commitment 1`] = `
 {

--- a/packages/api/test/__snapshots__/blob.test.ts.snap
+++ b/packages/api/test/__snapshots__/blob.test.ts.snap
@@ -1,5 +1,101 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Blob router > 'getByBlobId' > should fail when getting a blob and the blob data is not available > [TRPCError: Failed to get blob from any of the storages: ] 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
+
+exports[`Blob router > 'getByBlobId' > should fail when trying to get a blob by a non-existent hash > [TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.] 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
+
+exports[`Blob router > 'getByBlobId' > should get a blob by kzg commitment 1`] = `
+{
+  "commitment": "commitment004",
+  "data": "0xd76df869b71d79f835db7e39ebbf3d69b71d7e",
+  "proof": "proof004",
+  "size": 1300,
+  "versionedHash": "blobHash004",
+}
+`;
+
+exports[`Blob router > 'getByBlobId' > should get a blob by versioned hash 1`] = `
+{
+  "commitment": "commitment004",
+  "data": "0xd76df869b71d79f835db7e39ebbf3d69b71d7e",
+  "proof": "proof004",
+  "size": 1300,
+  "versionedHash": "blobHash004",
+}
+`;
+
+exports[`Blob router > 'getByBlobIdFull' > should fail when getting a blob and the blob data is not available > [TRPCError: Failed to get blob from any of the storages: ] 1`] = `[TRPCError: Failed to get blob from any of the storages: ]`;
+
+exports[`Blob router > 'getByBlobIdFull' > should fail when trying to get a blob by a non-existent hash > [TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.] 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;
+
+exports[`Blob router > 'getByBlobIdFull' > should get a blob by kzg commitment 1`] = `
+{
+  "commitment": "commitment004",
+  "data": "0xd76df869b71d79f835db7e39ebbf3d69b71d7e",
+  "dataStorageReferences": [
+    {
+      "blobStorage": "POSTGRES",
+      "dataReference": "blobHash004",
+    },
+    {
+      "blobStorage": "GOOGLE",
+      "dataReference": "7011893058/ob/Ha/sh/obHash004.txt",
+    },
+  ],
+  "proof": "proof004",
+  "size": 1300,
+  "transactions": [
+    {
+      "txHash": "txHash004",
+    },
+    {
+      "txHash": "txHash015",
+    },
+    {
+      "txHash": "txHash015",
+    },
+    {
+      "txHash": "txHash015",
+    },
+  ],
+  "versionedHash": "blobHash004",
+}
+`;
+
+exports[`Blob router > 'getByBlobIdFull' > should get a blob by versioned hash 1`] = `
+{
+  "commitment": "commitment004",
+  "data": "0xd76df869b71d79f835db7e39ebbf3d69b71d7e",
+  "dataStorageReferences": [
+    {
+      "blobStorage": "POSTGRES",
+      "dataReference": "blobHash004",
+    },
+    {
+      "blobStorage": "GOOGLE",
+      "dataReference": "7011893058/ob/Ha/sh/obHash004.txt",
+    },
+  ],
+  "proof": "proof004",
+  "size": 1300,
+  "transactions": [
+    {
+      "txHash": "txHash004",
+    },
+    {
+      "txHash": "txHash015",
+    },
+    {
+      "txHash": "txHash015",
+    },
+    {
+      "txHash": "txHash015",
+    },
+  ],
+  "versionedHash": "blobHash004",
+}
+`;
+
 exports[`Blob router > getAll > when getting paginated blob results > should default to the first page when no page was specified 1`] = `
 [
   {

--- a/packages/api/test/blob.test.ts
+++ b/packages/api/test/blob.test.ts
@@ -70,9 +70,7 @@ describe("Blob router", async () => {
         caller.blob[functionName]({
           id: "nonExistingHash",
         })
-      ).rejects.toMatchSnapshot(
-        "[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]"
-      );
+      ).rejects.toMatchSnapshot();
     });
 
     it("should fail when getting a blob and the blob data is not available", async () => {
@@ -81,9 +79,7 @@ describe("Blob router", async () => {
         caller.blob[functionName]({
           id: "blobHash003",
         })
-      ).rejects.toMatchSnapshot(
-        "[TRPCError: Failed to get blob from any of the storages: ]"
-      );
+      ).rejects.toMatchSnapshot();
     });
   });
 });

--- a/packages/api/test/blob.test.ts
+++ b/packages/api/test/blob.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { inferProcedureInput } from "@trpc/server";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -37,13 +38,17 @@ describe("Blob router", async () => {
     });
   });
 
-  describe("getByBlobId", () => {
+  describe.each([
+    { functionName: "getByBlobId" },
+    { functionName: "getByBlobIdFull" },
+  ])("$functionName", ({ functionName }) => {
     it("should get a blob by versioned hash", async () => {
       const input: GetByIdInput = {
         id: "blobHash004",
       };
 
-      const result = await caller.blob.getByBlobId(input);
+      // @ts-ignore
+      const result = await caller.blob[functionName](input);
 
       expect(result).toMatchSnapshot();
     });
@@ -53,27 +58,30 @@ describe("Blob router", async () => {
         id: "commitment004",
       };
 
-      const result = await caller.blob.getByBlobId(input);
+      // @ts-ignore
+      const result = await caller.blob[functionName](input);
 
       expect(result).toMatchSnapshot();
     });
 
     it("should fail when trying to get a blob by a non-existent hash", async () => {
       await expect(
-        caller.blob.getByBlobId({
+        // @ts-ignore
+        caller.blob[functionName]({
           id: "nonExistingHash",
         })
-      ).rejects.toMatchInlineSnapshot(
+      ).rejects.toMatchSnapshot(
         "[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]"
       );
     });
 
     it("should fail when getting a blob and the blob data is not available", async () => {
       await expect(
-        caller.blob.getByBlobId({
+        // @ts-ignore
+        caller.blob[functionName]({
           id: "blobHash003",
         })
-      ).rejects.toMatchInlineSnapshot(
+      ).rejects.toMatchSnapshot(
         "[TRPCError: Failed to get blob from any of the storages: ]"
       );
     });


### PR DESCRIPTION
Resolves #238 

- [x] Evaluate if still make sense to allow navigation directly from blob to block.

<img width="2560" alt="Screenshot 2024-03-12 at 4 26 23 AM" src="https://github.com/Blobscan/blobscan/assets/9082013/658c177f-c25b-4ce0-beaf-84468c627077">
