### PR TITLE
feat(blob-propagation-jobs-cli): add `count` and `get` command

### DIFF
--- a/.changeset/happy-suits-obey.md
+++ b/.changeset/happy-suits-obey.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/blob-propagation-jobs-cli": minor
+---
+
+Added `count` command

--- a/.changeset/slow-dancers-study.md
+++ b/.changeset/slow-dancers-study.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/blob-propagation-jobs-cli": minor
+---
+
+Added `get` command that allows to retrieve blob propagation jobs by different filters

--- a/.changeset/weak-bags-grow.md
+++ b/.changeset/weak-bags-grow.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/blob-propagation-jobs-cli": patch
+---
+
+Added type checkers to option definitions

--- a/clis/blob-propagation-jobs-cli/src/commands/count.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/count.ts
@@ -1,20 +1,16 @@
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
+import type { QueueHumanName } from "../Context";
 import { context } from "../context-instance";
-import {
-  helpOptionDef,
-  allQueuesOptionDef,
-  normalizeQueueName,
-} from "../utils";
-import type { Command } from "../utils";
+import type { Command } from "../types";
+import { helpOptionDef, queuesOptionDef } from "../utils";
 
 const countCommandOptDefs: commandLineArgs.OptionDefinition[] = [
   helpOptionDef,
   {
-    ...allQueuesOptionDef,
-    description:
-      "Queue to get the jobs count of. Valid values are {italic finalizer}, {italic google}, {italic postgres} or {italic swarm}.",
+    ...queuesOptionDef,
+    description: `Queue to get the jobs count of. ${queuesOptionDef.description}`,
   },
 ];
 
@@ -30,11 +26,11 @@ export const countCommandUsage = commandLineUsage([
 ]);
 
 export const count: Command = async function (argv) {
-  const { help, queue: rawQueueNames } = commandLineArgs(countCommandOptDefs, {
+  const { help, queue: queueNames } = commandLineArgs(countCommandOptDefs, {
     argv,
   }) as {
     help?: boolean;
-    queue?: string[];
+    queue?: QueueHumanName[];
   };
 
   if (help) {
@@ -43,9 +39,6 @@ export const count: Command = async function (argv) {
     return;
   }
 
-  const queueNames = rawQueueNames?.map((rawName) =>
-    normalizeQueueName(rawName)
-  );
   const queues = queueNames
     ? context.getQueues(queueNames)
     : context.getAllQueues();

--- a/clis/blob-propagation-jobs-cli/src/commands/count.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/count.ts
@@ -1,0 +1,61 @@
+import commandLineArgs from "command-line-args";
+import commandLineUsage from "command-line-usage";
+
+import { context } from "../context-instance";
+import {
+  helpOptionDef,
+  allQueuesOptionDef,
+  normalizeQueueName,
+} from "../utils";
+import type { Command } from "../utils";
+
+const countCommandOptDefs: commandLineArgs.OptionDefinition[] = [
+  helpOptionDef,
+  {
+    ...allQueuesOptionDef,
+    description:
+      "Queue to get the jobs count of. Valid values are {italic finalizer}, {italic google}, {italic postgres} or {italic swarm}.",
+  },
+];
+
+export const countCommandUsage = commandLineUsage([
+  {
+    header: "Count Command",
+    content: "Count propagation jobs.",
+  },
+  {
+    header: "Options",
+    optionList: countCommandOptDefs,
+  },
+]);
+
+export const count: Command = async function (argv) {
+  const { help, queue: rawQueueNames } = commandLineArgs(countCommandOptDefs, {
+    argv,
+  }) as {
+    help?: boolean;
+    queue?: string[];
+  };
+
+  if (help) {
+    console.log(countCommandUsage);
+
+    return;
+  }
+
+  const queueNames = rawQueueNames?.map((rawName) =>
+    normalizeQueueName(rawName)
+  );
+  const queues = queueNames
+    ? context.getQueues(queueNames)
+    : context.getAllQueues();
+
+  const jobCounts = await Promise.all(
+    queues.map(async (q) => ({
+      queueName: q.name,
+      count: await q.getJobCounts(),
+    }))
+  );
+
+  console.log(jobCounts);
+};

--- a/clis/blob-propagation-jobs-cli/src/commands/create.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/create.ts
@@ -93,16 +93,16 @@ export const create: Command = async function (argv) {
     blobHash: rawBlobHashes,
     help,
     storage: rawStorageNames,
-    from: rawFrom,
-    to: rawTo,
+    fromDate: rawFromDate,
+    toDate: rawToDate,
   } = commandLineArgs(createCommandOptDefs, {
     argv,
   }) as {
     blobHash?: string[];
     help?: boolean;
     storage?: string[];
-    from?: string;
-    to?: string;
+    fromDate?: string;
+    toDate?: string;
   };
 
   if (help) {
@@ -111,8 +111,8 @@ export const create: Command = async function (argv) {
     return;
   }
 
-  const from = rawFrom ? normalizeDate(rawFrom) : undefined;
-  const to = rawTo ? normalizeDate(rawTo) : undefined;
+  const from = rawFromDate ? normalizeDate(rawFromDate) : undefined;
+  const to = rawToDate ? normalizeDate(rawToDate) : undefined;
   const argStorageNames = rawStorageNames?.map((rawName) =>
     normalizeStorageQueueName(rawName)
   );

--- a/clis/blob-propagation-jobs-cli/src/commands/create.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/create.ts
@@ -7,16 +7,15 @@ import {
 } from "@blobscan/blob-propagator";
 import { prisma } from "@blobscan/db";
 
+import type { QueueHumanName } from "../Context";
 import { context } from "../context-instance";
 import { env } from "../env";
-import type { Command } from "../utils";
+import type { Command } from "../types";
 import {
   blobHashOptionDef,
   datePeriodOptionDefs,
   helpOptionDef,
-  normalizeBlobHashes,
-  normalizeDate,
-  normalizeStorageQueueName,
+  queuesOptionDef,
 } from "../utils";
 
 // TODO: Need to convert it to number explicity due to ci tests failing
@@ -31,13 +30,8 @@ const createCommandOptDefs: commandLineArgs.OptionDefinition[] = [
     description: "Blob hash of the blobs to create jobs for.",
   },
   {
-    name: "storage",
-    alias: "s",
-    typeLabel: "{underline storage}",
-    description:
-      "Storage used to propagate the selected blobs. Valid values are {italic google}, {italic postgres} or {italic swarm}.",
-    multiple: true,
-    type: String,
+    ...queuesOptionDef,
+    description: `Queue to create the jobs in. ${queuesOptionDef.description}`,
   },
   {
     ...datePeriodOptionDefs.from,
@@ -92,15 +86,15 @@ export const create: Command = async function (argv) {
   const {
     blobHash: rawBlobHashes,
     help,
-    storage: rawStorageNames,
-    fromDate: rawFromDate,
-    toDate: rawToDate,
+    queue: queueNames,
+    fromDate,
+    toDate,
   } = commandLineArgs(createCommandOptDefs, {
     argv,
   }) as {
     blobHash?: string[];
     help?: boolean;
-    storage?: string[];
+    queue?: QueueHumanName[];
     fromDate?: string;
     toDate?: string;
   };
@@ -111,19 +105,14 @@ export const create: Command = async function (argv) {
     return;
   }
 
-  const from = rawFromDate ? normalizeDate(rawFromDate) : undefined;
-  const to = rawToDate ? normalizeDate(rawToDate) : undefined;
-  const argStorageNames = rawStorageNames?.map((rawName) =>
-    normalizeStorageQueueName(rawName)
-  );
-  const storageQueues = argStorageNames
-    ? context.getQueuesOrThrow(argStorageNames)
+  const storageQueues = queueNames
+    ? context.getQueuesOrThrow(queueNames)
     : context.getAllStorageQueues();
   const storageQueueNames = storageQueues.map((q) => q.name);
   let blobHashes: string[];
 
   if (rawBlobHashes?.length) {
-    blobHashes = normalizeBlobHashes(rawBlobHashes);
+    blobHashes = [...new Set(rawBlobHashes.map((blobHash) => blobHash))];
 
     const dbBlobs = await prisma.blob.findMany({
       where: {
@@ -154,7 +143,7 @@ export const create: Command = async function (argv) {
     );
 
     await context.getPropagatorFlowProducer().addBulk(jobs);
-  } else if (from || to) {
+  } else if (fromDate || toDate) {
     await createBlobPropagationJobsInBatches(
       storageQueueNames,
       async (cursorId) => {
@@ -180,8 +169,8 @@ export const create: Command = async function (argv) {
           },
           where: {
             timestamp: {
-              gte: from,
-              lte: to,
+              gte: fromDate,
+              lte: toDate,
             },
           },
         });

--- a/clis/blob-propagation-jobs-cli/src/commands/get.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/get.ts
@@ -1,0 +1,296 @@
+import type { Job, JobState } from "bullmq";
+import commandLineArgs from "command-line-args";
+import commandLineUsage from "command-line-usage";
+
+import { buildJobId } from "@blobscan/blob-propagator";
+import type { BlobPropagationJobData } from "@blobscan/blob-propagator";
+import dayjs from "@blobscan/dayjs";
+import { prisma } from "@blobscan/db";
+
+import { context } from "../context-instance";
+import {
+  blobHashOptionDef,
+  helpOptionDef,
+  allQueuesOptionDef,
+  datePeriodOptionDefs,
+  normalizeBlobHashes,
+  normalizeQueueName,
+  blockRangeOptionDefs,
+  slotRangeOptionDefs,
+  sortOptionDefs,
+} from "../utils";
+import type { Command } from "../utils";
+
+type JobStatus = (typeof jobStatus)[number];
+
+const jobStatus = [
+  "completed",
+  "failed",
+  "waiting",
+  "waiting-children",
+  "delayed",
+  "prioritized",
+] as const;
+
+type PrintableJob = Pick<
+  Job<BlobPropagationJobData, any, string>,
+  "id" | "timestamp" | "attemptsMade" | "finishedOn" | "failedReason"
+> & { index: number; status: JobState | "unknown" };
+
+function printJob(j: PrintableJob) {
+  let jobLine = `Job ${j.index !== undefined ? `#${j.index}` : ""} | Id: ${
+    j.id
+  } | Status: ${j.status} | Timestamp: ${dayjs(j.timestamp)} | Attempts: ${
+    j.attemptsMade
+  }`;
+
+  if (j.finishedOn) {
+    jobLine += ` | Finished Date: ${dayjs(j.finishedOn)}`;
+  }
+
+  if (j.failedReason) {
+    jobLine += ` | Failed Reason: "${j.failedReason}"`;
+  }
+
+  console.log(jobLine);
+}
+
+const getCommandOptDefs: commandLineArgs.OptionDefinition[] = [
+  helpOptionDef,
+  {
+    ...blobHashOptionDef,
+    description: "Hash of the blob to get the job of",
+  },
+  {
+    ...allQueuesOptionDef,
+    description:
+      "Queue to get the jobs from. Valid values are {italic finalizer}, {italic google}, {italic postgres} or {italic swarm}.",
+  },
+  {
+    ...datePeriodOptionDefs.from,
+    description: "Date from which to retrieve blobs to get the jobs of.",
+  },
+  {
+    ...datePeriodOptionDefs.to,
+    description: "Date to which to retrieve blobs to get the jobs of.",
+  },
+  {
+    ...slotRangeOptionDefs.from,
+    description: "Slot from which to retrieve blobs to get the jobs of.",
+  },
+  {
+    ...slotRangeOptionDefs.to,
+    description: "Slot to which to retrieve blobs to get the jobs of.",
+  },
+  {
+    ...blockRangeOptionDefs.from,
+    description: "Block from which to retrieve blobs to get the jobs of.",
+  },
+  {
+    ...blockRangeOptionDefs.to,
+    description: "Block to which to retrieve blobs to get the jobs of.",
+  },
+  {
+    name: "status",
+    alias: "t",
+    description:
+      "Status of the jobs to get. Valid values are {italic completed}, {italic failed}, {italic waiting}, {italic waiting-children}, {italic delayed} or {italic prioritized}.",
+    type: (value: string): JobStatus => {
+      if (!jobStatus.includes(value as JobStatus)) {
+        throw new Error(
+          `Invalid status value. Valid values are ${jobStatus.join(", ")}.`
+        );
+      }
+
+      return value as JobStatus;
+    },
+    defaultValue: "failed",
+  },
+  {
+    name: "fromIndex",
+    alias: "i",
+    description: "Index of the first job to get.",
+    type: Number,
+    defaultValue: 0,
+  },
+  {
+    name: "toIndex",
+    alias: "f",
+    description: "Index of the last job to get.",
+    type: Number,
+    defaultValue: 500,
+  },
+  sortOptionDefs,
+];
+
+export const getCommandUsage = commandLineUsage([
+  {
+    header: "Get Command",
+    content: "Get propagation jobs.",
+  },
+  {
+    header: "Options",
+    optionList: getCommandOptDefs,
+  },
+]);
+
+export const get: Command = async function (argv) {
+  const {
+    blobHash: rawBlobHashes,
+    help,
+    queue: rawQueueNames,
+    fromBlock,
+    toBlock,
+    fromDate: rawFromDate,
+    toDate: rawToDate,
+    fromSlot,
+    toSlot,
+    fromIndex,
+    toIndex,
+    status,
+    sort,
+  } = commandLineArgs(getCommandOptDefs, {
+    argv,
+  }) as {
+    blobHash?: string[];
+    help?: boolean;
+    queue?: string[];
+    fromBlock: number;
+    toBlock: number;
+    fromDate?: string;
+    toDate?: string;
+    fromSlot?: number;
+    toSlot?: number;
+    fromIndex: number;
+    toIndex: number;
+    status: JobState;
+    sort: "asc" | "desc";
+  };
+
+  if (help) {
+    console.log(getCommandUsage);
+
+    return;
+  }
+
+  const queueNames = rawQueueNames?.map((rawName) =>
+    normalizeQueueName(rawName)
+  );
+  const queues = queueNames
+    ? context.getQueues(queueNames)
+    : context.getAllQueues();
+  let blobHashes: string[] = rawBlobHashes
+    ? normalizeBlobHashes(rawBlobHashes)
+    : [];
+  const fromDate = rawFromDate ? new Date(rawFromDate) : undefined;
+  const toDate = rawToDate ? new Date(rawToDate) : undefined;
+
+  const filtersProvided =
+    fromBlock || toBlock || fromDate || toDate || fromSlot || toSlot;
+
+  if (fromBlock && toBlock && toBlock < fromBlock) {
+    throw new Error("toBlock must be greater than fromBlock.");
+  }
+
+  if (fromSlot && toSlot && toSlot < fromSlot) {
+    throw new Error("toSlot must be greater than fromSlot.");
+  }
+
+  if (blobHashes.length) {
+    blobHashes = normalizeBlobHashes(blobHashes);
+  } else if (filtersProvided) {
+    const dbBlobs = await prisma.blobsOnTransactions.findMany({
+      take: toIndex - fromIndex,
+      skip: fromIndex,
+      select: {
+        blobHash: true,
+        transaction: {
+          select: {
+            block: {
+              select: {
+                timestamp: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        transaction: {
+          block: {
+            number: sort,
+          },
+        },
+      },
+      where: {
+        transaction: {
+          block: {
+            number:
+              fromBlock || toBlock
+                ? { gte: fromBlock, lte: toBlock }
+                : undefined,
+            slot:
+              fromSlot || toSlot ? { gte: fromSlot, lte: toSlot } : undefined,
+            timestamp:
+              fromDate || toDate ? { gte: fromDate, lte: toDate } : undefined,
+          },
+        },
+      },
+    });
+
+    if (!dbBlobs.length) {
+      console.log("No blobs found with the provided filters.");
+
+      return;
+    }
+
+    blobHashes = [...new Set(dbBlobs.map((dbBlob) => dbBlob.blobHash))];
+  }
+
+  if (blobHashes.length) {
+    const jobPromises = queues.flatMap((q) => {
+      let index = fromIndex;
+
+      return blobHashes.map<Promise<PrintableJob | undefined>>(async (hash) => {
+        const jobId = buildJobId(q.name, hash);
+
+        const [j, status] = await Promise.all([
+          q.getJob(jobId),
+          q.getJobState(jobId),
+        ]);
+
+        return j ? { ...j, status, index: index++ } : undefined;
+      });
+    });
+
+    const jobs = await Promise.all(jobPromises);
+    const existingJobs = jobs.filter((j): j is PrintableJob => !!j);
+
+    if (!existingJobs?.length) {
+      console.log("No blob propagation jobs found.");
+
+      return;
+    }
+
+    existingJobs.forEach(printJob);
+
+    return;
+  }
+
+  const jobs = (
+    await Promise.all(
+      queues.map((q) =>
+        q.getJobs(status, fromIndex, toIndex, sort === "asc").then((jobs) => {
+          let index = fromIndex;
+
+          return jobs.map<PrintableJob>((j) => ({
+            ...j,
+            index: index++,
+            status,
+          }));
+        })
+      )
+    )
+  ).flat();
+
+  jobs.forEach(printJob);
+};

--- a/clis/blob-propagation-jobs-cli/src/commands/index.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+export * from "./get";
 export * from "./count";
 export * from "./create";
 export * from "./remove";

--- a/clis/blob-propagation-jobs-cli/src/commands/index.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+export * from "./count";
 export * from "./create";
 export * from "./remove";
 export * from "./retry";

--- a/clis/blob-propagation-jobs-cli/src/commands/remove.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/remove.ts
@@ -1,20 +1,19 @@
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
+import type { QueueHumanName } from "../Context";
 import { context } from "../context-instance";
-import type { Command } from "../utils";
-import {
-  blobHashOptionDef,
-  getJobsByBlobHashes,
-  helpOptionDef,
-  allQueuesOptionDef,
-  normalizeQueueName,
-} from "../utils";
+import type { Command } from "../types";
+import { getJobsByBlobHashes } from "../utils";
+import { blobHashOptionDef, helpOptionDef, queuesOptionDef } from "../utils";
 
 const removeCommandOptDefs: commandLineArgs.OptionDefinition[] = [
   helpOptionDef,
-  allQueuesOptionDef,
   blobHashOptionDef,
+  {
+    ...queuesOptionDef,
+    description: `Queue to remove the jobs from. ${queuesOptionDef.description}`,
+  },
   {
     name: "force",
     alias: "f",
@@ -39,14 +38,14 @@ export const remove: Command = async function (argv) {
     blobHash: blobHashes,
     force = false,
     help,
-    queue: rawQueueNames,
+    queue: queueNames,
   } = commandLineArgs(removeCommandOptDefs, {
     argv,
   }) as {
     blobHash?: string[];
     force?: boolean;
     help?: boolean;
-    queue?: string[];
+    queue?: QueueHumanName[];
   };
 
   if (help) {
@@ -54,10 +53,6 @@ export const remove: Command = async function (argv) {
 
     return;
   }
-
-  const queueNames = rawQueueNames?.map((rawName) =>
-    normalizeQueueName(rawName)
-  );
 
   const queues = queueNames
     ? context.getQueues(queueNames)

--- a/clis/blob-propagation-jobs-cli/src/commands/retry.ts
+++ b/clis/blob-propagation-jobs-cli/src/commands/retry.ts
@@ -1,20 +1,19 @@
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
+import type { QueueHumanName } from "../Context";
 import { context } from "../context-instance";
-import type { Command } from "../utils";
-import {
-  blobHashOptionDef,
-  getJobsByBlobHashes,
-  helpOptionDef,
-  allQueuesOptionDef,
-  normalizeQueueName,
-} from "../utils";
+import type { Command } from "../types";
+import { getJobsByBlobHashes } from "../utils";
+import { blobHashOptionDef, helpOptionDef, queuesOptionDef } from "../utils";
 
 const retryCommandOptDefs: commandLineArgs.OptionDefinition[] = [
   helpOptionDef,
-  allQueuesOptionDef,
   blobHashOptionDef,
+  {
+    ...queuesOptionDef,
+    description: `Queue to retry the jobs from. ${queuesOptionDef.description}`,
+  },
 ];
 
 export const retryCommandUsage = commandLineUsage([
@@ -31,13 +30,13 @@ export const retryCommandUsage = commandLineUsage([
 export const retry: Command = async function (argv?: string[]) {
   const {
     help,
-    queue: rawQueueNames,
+    queue: queueNames,
     blobHash: blobHashes,
   } = commandLineArgs(retryCommandOptDefs, {
     argv,
   }) as {
     help?: boolean;
-    queue?: string[];
+    queue?: QueueHumanName[];
     blobHash?: string[];
   };
 
@@ -47,9 +46,6 @@ export const retry: Command = async function (argv?: string[]) {
     return;
   }
 
-  const queueNames = rawQueueNames?.map((rawName) =>
-    normalizeQueueName(rawName)
-  );
   const queues = queueNames
     ? context.getQueues(queueNames)
     : context.getAllQueues();

--- a/clis/blob-propagation-jobs-cli/src/main.ts
+++ b/clis/blob-propagation-jobs-cli/src/main.ts
@@ -1,7 +1,7 @@
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
-import { count, create, remove, retry } from "./commands";
+import { count, create, get, remove, retry } from "./commands";
 import { helpOptionDef } from "./utils";
 
 const mainDefs: commandLineUsage.OptionDefinition[] = [
@@ -19,6 +19,7 @@ export const mainUsage = commandLineUsage([
     content: [
       { name: "{bold count}", summary: "Count blob propagation jobs" },
       { name: "{bold create}", summary: "Create blob propagation jobs" },
+      { name: "{bold get}", summary: "Get blob propagation jobs" },
       { name: "{bold remove}", summary: "Remove blob propagation jobs" },
       { name: "{bold retry}", summary: "Retries failed jobs" },
     ],
@@ -63,6 +64,8 @@ export async function main() {
       return count(argv);
     case "create":
       return create(argv);
+    case "get":
+      return get(argv);
     case "remove":
       return remove(argv);
     case "retry":

--- a/clis/blob-propagation-jobs-cli/src/main.ts
+++ b/clis/blob-propagation-jobs-cli/src/main.ts
@@ -1,7 +1,7 @@
 import commandLineArgs from "command-line-args";
 import commandLineUsage from "command-line-usage";
 
-import { create, remove, retry } from "./commands";
+import { count, create, remove, retry } from "./commands";
 import { helpOptionDef } from "./utils";
 
 const mainDefs: commandLineUsage.OptionDefinition[] = [
@@ -16,7 +16,12 @@ export const mainUsage = commandLineUsage([
   },
   {
     header: "Command List",
-    content: [{ name: "{bold retry}", summary: "Retries failed jobs" }],
+    content: [
+      { name: "{bold count}", summary: "Count blob propagation jobs" },
+      { name: "{bold create}", summary: "Create blob propagation jobs" },
+      { name: "{bold remove}", summary: "Remove blob propagation jobs" },
+      { name: "{bold retry}", summary: "Retries failed jobs" },
+    ],
   },
   {
     header: "Options",
@@ -54,6 +59,8 @@ export async function main() {
   }
 
   switch (command) {
+    case "count":
+      return count(argv);
     case "create":
       return create(argv);
     case "remove":

--- a/clis/blob-propagation-jobs-cli/src/types.ts
+++ b/clis/blob-propagation-jobs-cli/src/types.ts
@@ -1,0 +1,1 @@
+export type Command<R = unknown> = (argv?: string[]) => Promise<R>;

--- a/clis/blob-propagation-jobs-cli/src/utils.ts
+++ b/clis/blob-propagation-jobs-cli/src/utils.ts
@@ -5,6 +5,36 @@ import { STORAGE_WORKER_NAMES, buildJobId } from "@blobscan/blob-propagator";
 import dayjs from "@blobscan/dayjs";
 import type { $Enums } from "@blobscan/db";
 
+function isPositiveInteger(value: string | number) {
+  const number = Number(value);
+
+  return !isNaN(number) && Number.isInteger(number) && number >= 0;
+}
+
+const blockType = (input: string): number => {
+  const value = Number(input);
+
+  if (!isPositiveInteger(value)) {
+    throw new Error(
+      `Invalid value "${input}". Block must be a positive integer.`
+    );
+  }
+
+  return value;
+};
+
+const slotType = (input: string): number => {
+  const value = Number(input);
+
+  if (!isPositiveInteger(value)) {
+    throw new Error(
+      `Invalid value "${input}". Slot must be a positive integer.`
+    );
+  }
+
+  return value;
+};
+
 export type Command<R = unknown> = (argv?: string[]) => Promise<R>;
 
 export const helpOptionDef: commandLineUsage.OptionDefinition = {
@@ -48,19 +78,58 @@ export const datePeriodOptionDefs: Record<
   commandLineUsage.OptionDefinition
 > = {
   from: {
-    name: "from",
-    alias: "f",
-    typeLabel: "{underline from}",
+    name: "fromDate",
+    typeLabel: "{underline from-date}",
     description: "Date from which execute jobs.",
     type: String,
   },
   to: {
-    name: "to",
-    alias: "t",
-    typeLabel: "{underline to}",
+    name: "toDate",
+    typeLabel: "{underline to-date}",
     description: "Date to which execute jobs.",
     type: String,
   },
+};
+
+export const slotRangeOptionDefs = {
+  from: {
+    name: "fromSlot",
+    typeLabel: "{underline from-slot}",
+    type: slotType,
+  },
+  to: {
+    name: "toSlot",
+    typeLabel: "{underline to-slot}",
+    type: slotType,
+  },
+};
+
+export const blockRangeOptionDefs = {
+  from: {
+    name: "fromBlock",
+    typeLabel: "{underline from-block}",
+    type: blockType,
+  },
+  to: {
+    name: "toBlock",
+    typeLabel: "{underline to-block}",
+    type: blockType,
+  },
+};
+
+export const sortOptionDefs = {
+  name: "sort",
+  alias: "s",
+  description:
+    "Sort the jobs in ascending or descending order. Valid values are {italic asc} or {italic desc}. Default is {italic desc}.",
+  type: (value: string): "asc" | "desc" => {
+    if (value !== "asc" && value !== "desc") {
+      throw new Error("Sort must be 'asc' or 'desc'.");
+    }
+
+    return value as "asc" | "desc";
+  },
+  defaultValue: "desc",
 };
 
 export function normalizeQueueName(input: string) {

--- a/clis/blob-propagation-jobs-cli/src/utils/index.ts
+++ b/clis/blob-propagation-jobs-cli/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./jobs";
+export * from "./options-defs";

--- a/clis/blob-propagation-jobs-cli/src/utils/jobs.ts
+++ b/clis/blob-propagation-jobs-cli/src/utils/jobs.ts
@@ -1,0 +1,18 @@
+import type { Queue } from "bullmq";
+
+import { buildJobId } from "@blobscan/blob-propagator";
+
+export async function getJobsByBlobHashes(queue: Queue, blobHashes: string[]) {
+  return Promise.all(
+    blobHashes.map(async (blobHash) => {
+      const jobId = buildJobId(queue.name, blobHash);
+      const job = await queue.getJob(jobId);
+
+      if (!job) {
+        throw new Error(`Couldn't find job with id ${jobId}`);
+      }
+
+      return job;
+    })
+  );
+}

--- a/clis/blob-propagation-jobs-cli/test/commands/count.test.ts
+++ b/clis/blob-propagation-jobs-cli/test/commands/count.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { count, countCommandUsage } from "../../src/commands";
+import { argHelpTest } from "../helpers";
+
+describe("Count command", () => {
+  argHelpTest(count, countCommandUsage);
+
+  it("should count jobs for a set of given queues correctly", async () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementationOnce(() => void {});
+
+    await count(["-q", "google"]);
+
+    expect(consoleLogSpy).toHaveBeenCalledOnce();
+    expect(consoleLogSpy).toHaveBeenCalledWith([
+      {
+        count: {
+          active: 0,
+          completed: 0,
+          delayed: 0,
+          failed: 0,
+          paused: 0,
+          prioritized: 0,
+          waiting: 0,
+          ["waiting-children"]: 0,
+        },
+        queueName: "google-worker",
+      },
+    ]);
+  });
+
+  it("should count jobs for all queues correctly", async () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementationOnce(() => void {});
+
+    await count([]);
+
+    expect(consoleLogSpy).toHaveBeenCalledOnce();
+    expect(consoleLogSpy).toHaveBeenCalledWith([
+      {
+        count: {
+          active: 0,
+          completed: 0,
+          delayed: 0,
+          failed: 0,
+          paused: 0,
+          prioritized: 0,
+          waiting: 0,
+          ["waiting-children"]: 0,
+        },
+        queueName: "google-worker",
+      },
+      {
+        count: {
+          active: 0,
+          completed: 0,
+          delayed: 0,
+          failed: 0,
+          paused: 0,
+          prioritized: 0,
+          waiting: 0,
+          ["waiting-children"]: 0,
+        },
+        queueName: "postgres-worker",
+      },
+      {
+        count: {
+          active: 0,
+          completed: 0,
+          delayed: 0,
+          failed: 0,
+          paused: 0,
+          prioritized: 0,
+          waiting: 0,
+          ["waiting-children"]: 0,
+        },
+        queueName: "finalizer-worker",
+      },
+    ]);
+  });
+});

--- a/clis/blob-propagation-jobs-cli/test/commands/create.test.ts
+++ b/clis/blob-propagation-jobs-cli/test/commands/create.test.ts
@@ -106,9 +106,9 @@ describe("Create command", () => {
 
   it("should fail when providing a non-existing storage", () => {
     expect(
-      create(["-s", "invalid-storage-name"])
+      create(["-q", "invalid-storage-name"])
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"Invalid queue name: invalid-storage-name"'
+      `"Invalid queue 'invalid-storage-name'. Valid values are finalizer, file_system, google, postgres, swarm."`
     );
   });
 

--- a/clis/blob-propagation-jobs-cli/test/commands/create.test.ts
+++ b/clis/blob-propagation-jobs-cli/test/commands/create.test.ts
@@ -69,7 +69,7 @@ describe("Create command", () => {
   it("should create jobs for all blobs greater than a given date correctly", async () => {
     const from = "2023-08-25";
 
-    await create(["-f", from]);
+    await create(["--fromDate", from]);
 
     const expectedBlobHashes = await fetchBlobHashesByDatePeriod(from);
 
@@ -81,7 +81,7 @@ describe("Create command", () => {
   it("should create jobs for all blobs less than a given date correctly", async () => {
     const to = "2022-12-20";
 
-    await create(["-t", to]);
+    await create(["--toDate", to]);
 
     const expectedBlobHashes = await fetchBlobHashesByDatePeriod(undefined, to);
     const createdJobs = await context.getJobs();
@@ -93,7 +93,7 @@ describe("Create command", () => {
     const from = "2023-08-25";
     const to = "2023-09-10";
 
-    await create(["-f", from, "-t", to]);
+    await create(["--fromDate", from, "--toDate", to]);
 
     const expectedBlobHashes = await fetchBlobHashesByDatePeriod(from, to);
 

--- a/clis/blob-propagation-jobs-cli/test/commands/remove.test.ts
+++ b/clis/blob-propagation-jobs-cli/test/commands/remove.test.ts
@@ -2,7 +2,6 @@
 import type { SpyInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { QueueHumanName } from "../../src/Context";
 import { remove, removeCommandUsage } from "../../src/commands";
 import { context } from "../../src/context-instance";
 import {
@@ -30,7 +29,7 @@ describe("Remove command", () => {
       const jobsBefore = await context.getJobs();
       const postgresQueue = context.getQueue("POSTGRES")!;
 
-      await remove(["-q", "POSTGRES"]);
+      await remove(["-q", "postgres"]);
 
       const jobsAfter = await context.getJobs();
       const postgresJobsAfter = await postgresQueue.getJobs();
@@ -80,7 +79,7 @@ describe("Remove command", () => {
     const blobHash1 = jobVersionedHashes[0] ?? "";
     const blobHash2 = jobVersionedHashes[1] ?? "";
 
-    await remove(["-q", "POSTGRES", "-b", blobHash1, "-b", blobHash2]);
+    await remove(["-q", "postgres", "-b", blobHash1, "-b", blobHash2]);
 
     const jobsAfter = await context.getJobs();
     const postgresJobs = await context.getQueue("POSTGRES")!.getJobs();
@@ -112,8 +111,8 @@ describe("Remove command", () => {
     });
 
     it("should force remove the selected queues", async () => {
-      const queueName1: QueueHumanName = "POSTGRES";
-      const queueName2: QueueHumanName = "GOOGLE";
+      const queueName1 = "postgres";
+      const queueName2 = "google";
 
       const queueSpy1 = queueSpies[0];
       const queueSpy2 = queueSpies[1];

--- a/clis/blob-propagation-jobs-cli/test/commands/retry.test.ts
+++ b/clis/blob-propagation-jobs-cli/test/commands/retry.test.ts
@@ -54,7 +54,7 @@ describe("Retry command", () => {
   });
 
   it("should retry failed jobs from a specific queue correctly", async () => {
-    await retry(["-q", "POSTGRES"]);
+    await retry(["-q", "postgres"]);
 
     const failedJobsAfterRetry = await context.getJobs(["failed"]);
     const postgresFailedJobs = failedJobsAfterRetry.filter((j) =>

--- a/clis/blob-propagation-jobs-cli/test/helpers.ts
+++ b/clis/blob-propagation-jobs-cli/test/helpers.ts
@@ -9,7 +9,7 @@ import type {
 } from "@blobscan/blob-propagator";
 
 import type { context } from "../src/context-instance";
-import type { Command } from "../src/utils";
+import type { Command } from "../src/types";
 
 export function setUpJobs(
   queues: BlobPropagationQueue[],
@@ -94,7 +94,7 @@ export function argInvalidQueueTests(c: Command) {
     expect(
       c(["-q", "invalid-queue-name"])
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"Invalid queue name: invalid-queue-name"'
+      `"Invalid queue 'invalid-queue-name'. Valid values are finalizer, file_system, google, postgres, swarm."`
     );
   });
 }

--- a/clis/blob-propagation-jobs-cli/test/helpers.ts
+++ b/clis/blob-propagation-jobs-cli/test/helpers.ts
@@ -75,7 +75,7 @@ export function argHelpTest(c: Command, expectedDisplayedUsage: string) {
   it("should display the command usage when the help flag is given", async () => {
     const consoleLogSpy = vi
       .spyOn(console, "log")
-      .mockImplementation(() => void {});
+      .mockImplementationOnce(() => void {});
 
     await c(["-h"]);
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:dev": "pnpm test:setup && pnpm test",
     "type-check": "turbo type-check",
     "stats": "pnpm -F stats-aggregation-cli start",
+    "propagator": "pnpm -F blob-propagation-jobs-cli start",
     "svg:format": "turbo svg:format",
     "validate": "turbo lint type-check && manypkg check && pnpm test"
   },


### PR DESCRIPTION
This PR adds the following commands:

```
Count Command

  Count propagation jobs. 

Options

  -h, --help          Print this usage guide.                                   
  -q, --queue queue   Queue to get the jobs count of. Valid values are          
                      finalizer, file_system, google, postgres, swarm


Get Command

  Get propagation jobs. 

Options

  -h, --help                 Print this usage guide.                            
  -b, --blobHash blob-hash   Hash of the blob to get the job of                 
  -q, --queue queue          Queue to get the jobs from. Valid values are       
                             finalizer, file_system, google, postgres, swarm    
  --fromDate from-date       Date from which to retrieve blobs to get the jobs  
                             of.                                                
  --toDate to-date           Date to which to retrieve blobs to get the jobs    
                             of.                                                
  --fromSlot from-slot       Slot from which to retrieve blobs to get the jobs  
                             of.                                                
  --toSlot to-slot           Slot to which to retrieve blobs to get the jobs    
                             of.                                                
  --fromBlock from-block     Block from which to retrieve blobs to get the jobs 
                             of.                                                
  --toBlock to-block         Block to which to retrieve blobs to get the jobs   
                             of.                                                
  -t, --status type          Status of the jobs to get. Valid values are        
                             completed, failed, waiting, waiting-children,      
                             delayed or prioritized.                            
  -i, --fromIndex number     Index of the first job to get.                     
  -f, --toIndex number       Index of the last job to get.                      
  -s, --sort type            Sort the jobs in ascending or descending order.    
                             Valid values are asc or desc. Default is desc. 
```