### PR TITLE
fix: remove dupe env var in cli banner

### DIFF
--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -105,7 +105,7 @@ export const env = createEnv({
         env.METRICS_ENABLED
       } traces=${env.TRACES_ENABLED} port=${
         env.BLOBSCAN_API_PORT
-      } redisUri=${maskPassword(env.REDIS_URI)} dailyStatsCron=${
+      } dailyStatsCron=${
         env.STATS_SYNCER_DAILY_CRON_PATTERN
       } overallStatsCron=${
         env.STATS_SYNCER_OVERALL_CRON_PATTERN


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This variable was being displayed twice

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
