### PR TITLE
feat: display transaction index

### DIFF
--- a/.changeset/lemon-worms-clap.md
+++ b/.changeset/lemon-worms-clap.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Displayed transaction index on transaction details page

--- a/.changeset/modern-walls-complain.md
+++ b/.changeset/modern-walls-complain.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Performed sorting of block's transactions and blobs directly in the db query instead of during serialization

--- a/apps/web/src/components/Cards/SurfaceCards/BlobTransactionCard.tsx
+++ b/apps/web/src/components/Cards/SurfaceCards/BlobTransactionCard.tsx
@@ -80,7 +80,6 @@ const BlobTransactionCard: FC<BlobTransactionCardProps> = function ({
   const displayBlobs = !compact && !!blobsOnTx?.length;
   const totalBlobSize = blobsOnTx?.reduce((acc, { size }) => acc + size, 0);
 
-  console.log(displayBlobs);
   return (
     <div>
       <SurfaceCardBase

--- a/apps/web/src/pages/tx/[hash].tsx
+++ b/apps/web/src/pages/tx/[hash].tsx
@@ -43,6 +43,7 @@ const Tx: NextPage = () => {
     return deserializeFullTransaction(rawTxData);
   }, [rawTxData]);
 
+  console.log(tx);
   if (error) {
     return (
       <NextError
@@ -92,6 +93,10 @@ const Tx: NextPage = () => {
             {formatTimestamp(block.timestamp)}
           </div>
         ),
+      },
+      {
+        name: "Position In Block",
+        value: tx.index,
       },
       {
         name: "From",

--- a/packages/api/src/routers/block/common/selects.ts
+++ b/packages/api/src/routers/block/common/selects.ts
@@ -37,7 +37,13 @@ export function createBlockSelect(expands: Expands) {
               },
             },
           },
+          orderBy: {
+            index: "asc",
+          },
         },
+      },
+      orderBy: {
+        index: "asc",
       },
     },
   });

--- a/packages/api/src/routers/block/common/serializers.ts
+++ b/packages/api/src/routers/block/common/serializers.ts
@@ -93,16 +93,14 @@ export function serializeBlock(block: QueriedBlock): SerializedBlock {
     transactions: rawTransactions,
   } = block;
 
-  const transactions = rawTransactions
-    .sort((a, b) => a.hash.localeCompare(b.hash))
-    .map((rawTx): SerializedBlock["transactions"][number] => {
+  const transactions = rawTransactions.map(
+    (rawTx): SerializedBlock["transactions"][number] => {
       const { hash, blobs } = rawTx;
-      const sortedBlobs = blobs.sort((a, b) => a.index - b.index);
 
       return {
         hash,
         ...serializeExpandedTransaction(rawTx),
-        blobs: sortedBlobs.map((blob) => {
+        blobs: blobs.map((blob) => {
           const { index, blobHash, blob: blobData } = blob;
 
           return {
@@ -112,7 +110,8 @@ export function serializeBlock(block: QueriedBlock): SerializedBlock {
           };
         }),
       };
-    });
+    }
+  );
 
   return {
     hash,


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

It solves #438.

This PR displays the recently-added transaction index on the transaction details page.

It also modifies the API to return a block’s transactions sorted by the newly added transaction index.

### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):

![image](https://github.com/Blobscan/blobscan/assets/33203511/aa00d654-7f31-4ba3-9223-cceac7131fb7)
