### PR TITLE
feat: add filter to retrieve entities that have/contain no rollup 

### DIFF
--- a/.changeset/fuzzy-deers-glow.md
+++ b/.changeset/fuzzy-deers-glow.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": minor
+---
+
+Added support to filter entities (blobs, blocks or transactions) by no rollup

--- a/packages/api/src/middlewares/withFilters.ts
+++ b/packages/api/src/middlewares/withFilters.ts
@@ -5,7 +5,7 @@ import { t } from "../trpc-client";
 import {
   addressSchema,
   blockNumberSchema,
-  rollupSchema,
+  nullableRollupSchema,
   slotSchema,
 } from "../utils";
 
@@ -45,7 +45,7 @@ export const withSlotRangeFilterSchema = z.object({
 });
 
 export const withRollupFilterSchema = z.object({
-  rollup: rollupSchema.optional(),
+  rollup: nullableRollupSchema.optional(),
 });
 
 export const withTypeFilterSchema = z.object({

--- a/packages/api/src/middlewares/withFilters.ts
+++ b/packages/api/src/middlewares/withFilters.ts
@@ -141,9 +141,10 @@ export const withFilters = t.middleware(({ next, input = {} }) => {
 
     filters.blockType = type === "reorged" ? { some: {} } : { none: {} };
 
-    filters.transactionRollup = rollup?.toUpperCase() as
-      | $Enums.Rollup
-      | undefined;
+    filters.transactionRollup =
+      rollup === "null"
+        ? null
+        : (rollup?.toUpperCase() as $Enums.Rollup | undefined);
     filters.sort = sort;
   }
 

--- a/packages/api/src/routers/blob/getAll.ts
+++ b/packages/api/src/routers/blob/getAll.ts
@@ -55,10 +55,14 @@ export const getAll = publicProcedure
             slot: filters.blockSlot,
             transactionForks: filters.blockType,
           },
-          transaction: {
-            rollup: filters.transactionRollup,
-            OR: filters.transactionAddresses,
-          },
+          transaction:
+            filters.transactionRollup !== undefined ||
+            filters.transactionAddresses
+              ? {
+                  rollup: filters.transactionRollup,
+                  OR: filters.transactionAddresses,
+                }
+              : undefined,
         },
         orderBy: [
           { blockNumber: filters.sort },

--- a/packages/api/src/routers/block/getAll.ts
+++ b/packages/api/src/routers/block/getAll.ts
@@ -56,7 +56,8 @@ export const getAll = publicProcedure
 
           transactionForks: filters.blockType,
           transactions:
-            filters.transactionRollup || filters.transactionAddresses
+            filters.transactionRollup !== undefined ||
+            filters.transactionAddresses
               ? {
                   some: {
                     rollup: filters.transactionRollup,

--- a/packages/api/src/utils/schemas.ts
+++ b/packages/api/src/utils/schemas.ts
@@ -27,7 +27,6 @@ const zodRollupEnums = [
   "zksync",
   "mode",
   "zora",
-  "null",
 ] as const;
 
 /**
@@ -76,6 +75,13 @@ export const rollupSchema = z
     return zodRollupEnums.includes(value as ZodRollupEnum);
   })
   .transform((value) => value as ZodRollupEnum);
+
+export const nullableRollupSchema = z
+  .string()
+  .refine((value) => {
+    return value === "null" || zodRollupEnums.includes(value as ZodRollupEnum);
+  })
+  .transform((value) => value as ZodRollupEnum | "null");
 
 export const blockNumberSchema = z.number().nonnegative();
 

--- a/packages/api/src/utils/schemas.ts
+++ b/packages/api/src/utils/schemas.ts
@@ -27,6 +27,7 @@ const zodRollupEnums = [
   "zksync",
   "mode",
   "zora",
+  "null",
 ] as const;
 
 /**
@@ -72,10 +73,7 @@ export const blobStorageSchema = z.enum(zodBlobStorageEnums);
 export const rollupSchema = z
   .string()
   .refine((value) => {
-    const isNull = value === null;
-    const isRollupEnum = zodRollupEnums.includes(value as ZodRollupEnum);
-
-    return isNull || isRollupEnum;
+    return zodRollupEnums.includes(value as ZodRollupEnum);
   })
   .transform((value) => value as ZodRollupEnum);
 

--- a/packages/api/test/__snapshots__/blob.test.ts.snap
+++ b/packages/api/test/__snapshots__/blob.test.ts.snap
@@ -198,6 +198,314 @@ exports[`Blob router > getAll > when getting expanded blob results > should retu
 ]
 `;
 
+exports[`Blob router > getAll > when getting filtered blob results > should only return the results that do not have a rollup when 'null' is provided 1`] = `
+[
+  {
+    "blockHash": "blockHash008",
+    "blockNumber": 1008,
+    "blockTimestamp": "2023-08-31T16:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash016",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash006",
+    "blockNumber": 1006,
+    "blockTimestamp": "2023-08-31T12:00:00.000Z",
+    "commitment": "0xb4f67eb0771fbbf1b06b88ce0e23383daf994320508d44dd30dbd507f598c0d9b3da5a152e41a0428375060c3803b983",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "postgres",
+        "dataReference": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash006",
+      },
+    ],
+    "index": 0,
+    "proof": "89cf91c4c8be6f2a390d4262425f79dffb74c174fb15a210182184543bf7394e5a7970a774ee8e0dabc315424c22df0f",
+    "size": 1500,
+    "txHash": "0x5be77167b05f39ea8950f11b0da2bdfec6e04055030068b051ac5a43aaf251e9",
+    "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
+  },
+  {
+    "blockHash": "blockHash005",
+    "blockNumber": 1005,
+    "blockTimestamp": "2023-08-28T10:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash013",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash004",
+    "blockNumber": 1004,
+    "blockTimestamp": "2023-08-20T12:00:00.000Z",
+    "commitment": "commitment003",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash003.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash003",
+      },
+    ],
+    "index": 0,
+    "proof": "proof003",
+    "size": 1200,
+    "txHash": "txHash010",
+    "versionedHash": "blobHash003",
+  },
+  {
+    "blockHash": "blockHash004",
+    "blockNumber": 1004,
+    "blockTimestamp": "2023-08-20T12:00:00.000Z",
+    "commitment": "commitment003",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash003.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash003",
+      },
+    ],
+    "index": 0,
+    "proof": "proof003",
+    "size": 1200,
+    "txHash": "txHash009",
+    "versionedHash": "blobHash003",
+  },
+  {
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 2,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash006",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 1,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash006",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash006",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 2,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash005",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "commitment": "commitment002",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash002.txt",
+      },
+    ],
+    "index": 1,
+    "proof": "proof002",
+    "size": 1100,
+    "txHash": "txHash005",
+    "versionedHash": "blobHash002",
+  },
+  {
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "commitment": "commitment002",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash002.txt",
+      },
+    ],
+    "index": 0,
+    "proof": "proof002",
+    "size": 1100,
+    "txHash": "txHash005",
+    "versionedHash": "blobHash002",
+  },
+  {
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash002",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "commitment": "commitment003",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash003.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash003",
+      },
+    ],
+    "index": 2,
+    "proof": "proof003",
+    "size": 1200,
+    "txHash": "txHash001",
+    "versionedHash": "blobHash003",
+  },
+  {
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "commitment": "commitment002",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash002.txt",
+      },
+    ],
+    "index": 1,
+    "proof": "proof002",
+    "size": 1100,
+    "txHash": "txHash001",
+    "versionedHash": "blobHash002",
+  },
+  {
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "txHash": "txHash001",
+    "versionedHash": "blobHash001",
+  },
+]
+`;
+
 exports[`Blob router > getAll > when getting filtered blob results > should return the latest results when no sort was specified 1`] = `
 [
   {
@@ -332,6 +640,223 @@ exports[`Blob router > getAll > when getting filtered blob results > should retu
     "size": 1200,
     "txHash": "txHash001",
     "versionedHash": "blobHash003",
+  },
+]
+`;
+
+exports[`Blob router > getAll > when getting filtered blob results > should return the results corresponding to a provided rollup 1`] = `
+[
+  {
+    "blockHash": "blockHash007",
+    "blockNumber": 1007,
+    "blockTimestamp": "2023-08-31T14:00:00.000Z",
+    "commitment": "commitment004",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash004.txt",
+      },
+      {
+        "blobStorage": "postgres",
+        "dataReference": "blobHash004",
+      },
+    ],
+    "index": 2,
+    "proof": "proof004",
+    "size": 1300,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash015",
+    "versionedHash": "blobHash004",
+  },
+  {
+    "blockHash": "blockHash007",
+    "blockNumber": 1007,
+    "blockTimestamp": "2023-08-31T14:00:00.000Z",
+    "commitment": "commitment004",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash004.txt",
+      },
+      {
+        "blobStorage": "postgres",
+        "dataReference": "blobHash004",
+      },
+    ],
+    "index": 1,
+    "proof": "proof004",
+    "size": 1300,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash015",
+    "versionedHash": "blobHash004",
+  },
+  {
+    "blockHash": "blockHash007",
+    "blockNumber": 1007,
+    "blockTimestamp": "2023-08-31T14:00:00.000Z",
+    "commitment": "commitment004",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash004.txt",
+      },
+      {
+        "blobStorage": "postgres",
+        "dataReference": "blobHash004",
+      },
+    ],
+    "index": 0,
+    "proof": "proof004",
+    "size": 1300,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash015",
+    "versionedHash": "blobHash004",
+  },
+  {
+    "blockHash": "blockHash005",
+    "blockNumber": 1005,
+    "blockTimestamp": "2023-08-28T10:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 2,
+    "proof": "proof001",
+    "size": 1000,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash012",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash005",
+    "blockNumber": 1005,
+    "blockTimestamp": "2023-08-28T10:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 1,
+    "proof": "proof001",
+    "size": 1000,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash012",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash005",
+    "blockNumber": 1005,
+    "blockTimestamp": "2023-08-28T10:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash012",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash004",
+    "blockNumber": 1004,
+    "blockTimestamp": "2023-08-20T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash007",
+    "versionedHash": "blobHash001",
+  },
+  {
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "commitment": "commitment002",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash002.txt",
+      },
+    ],
+    "index": 1,
+    "proof": "proof002",
+    "size": 1100,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash003",
+    "versionedHash": "blobHash002",
+  },
+  {
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "commitment": "commitment001",
+    "dataStorageReferences": [
+      {
+        "blobStorage": "google",
+        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
+      },
+      {
+        "blobStorage": "swarm",
+        "dataReference": "bzz://some-hash-for-blobHash001",
+      },
+    ],
+    "index": 0,
+    "proof": "proof001",
+    "size": 1000,
+    "transaction": {
+      "rollup": "optimism",
+    },
+    "txHash": "txHash003",
+    "versionedHash": "blobHash001",
   },
 ]
 `;
@@ -877,223 +1402,6 @@ exports[`Blob router > getAll > when getting filtered blob results > should retu
     "proof": "proof001",
     "size": 1000,
     "txHash": "txHash001",
-    "versionedHash": "blobHash001",
-  },
-]
-`;
-
-exports[`Blob router > getAll > when getting filtered blob results > should return the results corresponding to the rollup specified 1`] = `
-[
-  {
-    "blockHash": "blockHash007",
-    "blockNumber": 1007,
-    "blockTimestamp": "2023-08-31T14:00:00.000Z",
-    "commitment": "commitment004",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash004.txt",
-      },
-      {
-        "blobStorage": "postgres",
-        "dataReference": "blobHash004",
-      },
-    ],
-    "index": 2,
-    "proof": "proof004",
-    "size": 1300,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash015",
-    "versionedHash": "blobHash004",
-  },
-  {
-    "blockHash": "blockHash007",
-    "blockNumber": 1007,
-    "blockTimestamp": "2023-08-31T14:00:00.000Z",
-    "commitment": "commitment004",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash004.txt",
-      },
-      {
-        "blobStorage": "postgres",
-        "dataReference": "blobHash004",
-      },
-    ],
-    "index": 1,
-    "proof": "proof004",
-    "size": 1300,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash015",
-    "versionedHash": "blobHash004",
-  },
-  {
-    "blockHash": "blockHash007",
-    "blockNumber": 1007,
-    "blockTimestamp": "2023-08-31T14:00:00.000Z",
-    "commitment": "commitment004",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash004.txt",
-      },
-      {
-        "blobStorage": "postgres",
-        "dataReference": "blobHash004",
-      },
-    ],
-    "index": 0,
-    "proof": "proof004",
-    "size": 1300,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash015",
-    "versionedHash": "blobHash004",
-  },
-  {
-    "blockHash": "blockHash005",
-    "blockNumber": 1005,
-    "blockTimestamp": "2023-08-28T10:00:00.000Z",
-    "commitment": "commitment001",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
-      },
-      {
-        "blobStorage": "swarm",
-        "dataReference": "bzz://some-hash-for-blobHash001",
-      },
-    ],
-    "index": 2,
-    "proof": "proof001",
-    "size": 1000,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash012",
-    "versionedHash": "blobHash001",
-  },
-  {
-    "blockHash": "blockHash005",
-    "blockNumber": 1005,
-    "blockTimestamp": "2023-08-28T10:00:00.000Z",
-    "commitment": "commitment001",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
-      },
-      {
-        "blobStorage": "swarm",
-        "dataReference": "bzz://some-hash-for-blobHash001",
-      },
-    ],
-    "index": 1,
-    "proof": "proof001",
-    "size": 1000,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash012",
-    "versionedHash": "blobHash001",
-  },
-  {
-    "blockHash": "blockHash005",
-    "blockNumber": 1005,
-    "blockTimestamp": "2023-08-28T10:00:00.000Z",
-    "commitment": "commitment001",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
-      },
-      {
-        "blobStorage": "swarm",
-        "dataReference": "bzz://some-hash-for-blobHash001",
-      },
-    ],
-    "index": 0,
-    "proof": "proof001",
-    "size": 1000,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash012",
-    "versionedHash": "blobHash001",
-  },
-  {
-    "blockHash": "blockHash004",
-    "blockNumber": 1004,
-    "blockTimestamp": "2023-08-20T12:00:00.000Z",
-    "commitment": "commitment001",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
-      },
-      {
-        "blobStorage": "swarm",
-        "dataReference": "bzz://some-hash-for-blobHash001",
-      },
-    ],
-    "index": 0,
-    "proof": "proof001",
-    "size": 1000,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash007",
-    "versionedHash": "blobHash001",
-  },
-  {
-    "blockHash": "blockHash001",
-    "blockNumber": 1001,
-    "blockTimestamp": "2022-10-16T12:00:00.000Z",
-    "commitment": "commitment002",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash002.txt",
-      },
-    ],
-    "index": 1,
-    "proof": "proof002",
-    "size": 1100,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash003",
-    "versionedHash": "blobHash002",
-  },
-  {
-    "blockHash": "blockHash001",
-    "blockNumber": 1001,
-    "blockTimestamp": "2022-10-16T12:00:00.000Z",
-    "commitment": "commitment001",
-    "dataStorageReferences": [
-      {
-        "blobStorage": "google",
-        "dataReference": "70118930558/ob/Ha/sh/obHash001.txt",
-      },
-      {
-        "blobStorage": "swarm",
-        "dataReference": "bzz://some-hash-for-blobHash001",
-      },
-    ],
-    "index": 0,
-    "proof": "proof001",
-    "size": 1000,
-    "transaction": {
-      "rollup": "optimism",
-    },
-    "txHash": "txHash003",
     "versionedHash": "blobHash001",
   },
 ]

--- a/packages/api/test/__snapshots__/block.test.ts.snap
+++ b/packages/api/test/__snapshots__/block.test.ts.snap
@@ -304,6 +304,188 @@ exports[`Block router > getAll > when getting expanded block results > should re
 ]
 `;
 
+exports[`Block router > getAll > when getting filtered block results > should only return the results that do not have a rollup when 'null' is provided 1`] = `
+[
+  {
+    "blobAsCalldataGasUsed": "255000",
+    "blobGasPrice": "22",
+    "blobGasUsed": "5500000",
+    "excessBlobGas": "15000",
+    "hash": "blockHash008",
+    "number": 1008,
+    "slot": 108,
+    "timestamp": "2023-08-31T16:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash016",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "255000",
+    "blobGasPrice": "22",
+    "blobGasUsed": "5500000",
+    "excessBlobGas": "15000",
+    "hash": "blockHash006",
+    "number": 1006,
+    "slot": 106,
+    "timestamp": "2023-08-31T12:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
+          },
+        ],
+        "hash": "0x5be77167b05f39ea8950f11b0da2bdfec6e04055030068b051ac5a43aaf251e9",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "250000",
+    "blobGasPrice": "20",
+    "blobGasUsed": "5000000",
+    "excessBlobGas": "10000",
+    "hash": "blockHash005",
+    "number": 1005,
+    "slot": 105,
+    "timestamp": "2023-08-28T10:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash013",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "255000",
+    "blobGasPrice": "22",
+    "blobGasUsed": "5500000",
+    "excessBlobGas": "15000",
+    "hash": "blockHash004",
+    "number": 1004,
+    "slot": 104,
+    "timestamp": "2023-08-20T12:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash003",
+          },
+        ],
+        "hash": "txHash009",
+      },
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash003",
+          },
+        ],
+        "hash": "txHash010",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "255000",
+    "blobGasPrice": "22",
+    "blobGasUsed": "5500000",
+    "excessBlobGas": "15000",
+    "hash": "blockHash003",
+    "number": 1003,
+    "slot": 103,
+    "timestamp": "2023-08-03T12:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash002",
+          },
+          {
+            "index": 1,
+            "versionedHash": "blobHash002",
+          },
+          {
+            "index": 2,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash005",
+      },
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+          {
+            "index": 1,
+            "versionedHash": "blobHash001",
+          },
+          {
+            "index": 2,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash006",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "2042780",
+    "blobGasPrice": "22",
+    "blobGasUsed": "786432",
+    "excessBlobGas": "15000",
+    "hash": "blockHash001",
+    "number": 1001,
+    "slot": 101,
+    "timestamp": "2022-10-16T12:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+          {
+            "index": 1,
+            "versionedHash": "blobHash002",
+          },
+          {
+            "index": 2,
+            "versionedHash": "blobHash003",
+          },
+        ],
+        "hash": "txHash001",
+      },
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash002",
+      },
+    ],
+  },
+]
+`;
+
 exports[`Block router > getAll > when getting filtered block results > should return the latest results when no sort was specified 1`] = `
 [
   {
@@ -520,6 +702,119 @@ exports[`Block router > getAll > when getting filtered block results > should re
           },
         ],
         "hash": "txHash006",
+      },
+    ],
+  },
+]
+`;
+
+exports[`Block router > getAll > when getting filtered block results > should return the results corresponding to a provided rollup 1`] = `
+[
+  {
+    "blobAsCalldataGasUsed": "255000",
+    "blobGasPrice": "22",
+    "blobGasUsed": "5500000",
+    "excessBlobGas": "15000",
+    "hash": "blockHash007",
+    "number": 1007,
+    "slot": 107,
+    "timestamp": "2023-08-31T14:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash004",
+          },
+          {
+            "index": 1,
+            "versionedHash": "blobHash004",
+          },
+          {
+            "index": 2,
+            "versionedHash": "blobHash004",
+          },
+        ],
+        "hash": "txHash015",
+        "rollup": "optimism",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "250000",
+    "blobGasPrice": "20",
+    "blobGasUsed": "5000000",
+    "excessBlobGas": "10000",
+    "hash": "blockHash005",
+    "number": 1005,
+    "slot": 105,
+    "timestamp": "2023-08-28T10:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+          {
+            "index": 1,
+            "versionedHash": "blobHash001",
+          },
+          {
+            "index": 2,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash012",
+        "rollup": "optimism",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "255000",
+    "blobGasPrice": "22",
+    "blobGasUsed": "5500000",
+    "excessBlobGas": "15000",
+    "hash": "blockHash004",
+    "number": 1004,
+    "slot": 104,
+    "timestamp": "2023-08-20T12:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+        ],
+        "hash": "txHash007",
+        "rollup": "optimism",
+      },
+    ],
+  },
+  {
+    "blobAsCalldataGasUsed": "2042780",
+    "blobGasPrice": "22",
+    "blobGasUsed": "786432",
+    "excessBlobGas": "15000",
+    "hash": "blockHash001",
+    "number": 1001,
+    "slot": 101,
+    "timestamp": "2022-10-16T12:00:00.000Z",
+    "transactions": [
+      {
+        "blobs": [
+          {
+            "index": 0,
+            "versionedHash": "blobHash001",
+          },
+          {
+            "index": 1,
+            "versionedHash": "blobHash002",
+          },
+        ],
+        "hash": "txHash003",
+        "rollup": "optimism",
       },
     ],
   },
@@ -866,119 +1161,6 @@ exports[`Block router > getAll > when getting filtered block results > should re
         ],
         "hash": "txHash002",
       },
-      {
-        "blobs": [
-          {
-            "index": 0,
-            "versionedHash": "blobHash001",
-          },
-          {
-            "index": 1,
-            "versionedHash": "blobHash002",
-          },
-        ],
-        "hash": "txHash003",
-        "rollup": "optimism",
-      },
-    ],
-  },
-]
-`;
-
-exports[`Block router > getAll > when getting filtered block results > should return the results corresponding to the rollup specified 1`] = `
-[
-  {
-    "blobAsCalldataGasUsed": "255000",
-    "blobGasPrice": "22",
-    "blobGasUsed": "5500000",
-    "excessBlobGas": "15000",
-    "hash": "blockHash007",
-    "number": 1007,
-    "slot": 107,
-    "timestamp": "2023-08-31T14:00:00.000Z",
-    "transactions": [
-      {
-        "blobs": [
-          {
-            "index": 0,
-            "versionedHash": "blobHash004",
-          },
-          {
-            "index": 1,
-            "versionedHash": "blobHash004",
-          },
-          {
-            "index": 2,
-            "versionedHash": "blobHash004",
-          },
-        ],
-        "hash": "txHash015",
-        "rollup": "optimism",
-      },
-    ],
-  },
-  {
-    "blobAsCalldataGasUsed": "250000",
-    "blobGasPrice": "20",
-    "blobGasUsed": "5000000",
-    "excessBlobGas": "10000",
-    "hash": "blockHash005",
-    "number": 1005,
-    "slot": 105,
-    "timestamp": "2023-08-28T10:00:00.000Z",
-    "transactions": [
-      {
-        "blobs": [
-          {
-            "index": 0,
-            "versionedHash": "blobHash001",
-          },
-          {
-            "index": 1,
-            "versionedHash": "blobHash001",
-          },
-          {
-            "index": 2,
-            "versionedHash": "blobHash001",
-          },
-        ],
-        "hash": "txHash012",
-        "rollup": "optimism",
-      },
-    ],
-  },
-  {
-    "blobAsCalldataGasUsed": "255000",
-    "blobGasPrice": "22",
-    "blobGasUsed": "5500000",
-    "excessBlobGas": "15000",
-    "hash": "blockHash004",
-    "number": 1004,
-    "slot": 104,
-    "timestamp": "2023-08-20T12:00:00.000Z",
-    "transactions": [
-      {
-        "blobs": [
-          {
-            "index": 0,
-            "versionedHash": "blobHash001",
-          },
-        ],
-        "hash": "txHash007",
-        "rollup": "optimism",
-      },
-    ],
-  },
-  {
-    "blobAsCalldataGasUsed": "2042780",
-    "blobGasPrice": "22",
-    "blobGasUsed": "786432",
-    "excessBlobGas": "15000",
-    "hash": "blockHash001",
-    "number": 1001,
-    "slot": 101,
-    "timestamp": "2022-10-16T12:00:00.000Z",
-    "transactions": [
       {
         "blobs": [
           {

--- a/packages/api/test/__snapshots__/tx.test.ts.snap
+++ b/packages/api/test/__snapshots__/tx.test.ts.snap
@@ -309,6 +309,260 @@ exports[`Transaction router > getAll > when getting expanded transaction results
 ]
 `;
 
+exports[`Transaction router > getAll > when getting filtered transaction results > should only return the results that do not have a rollup when 'null' is provided 1`] = `
+[
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "2883584",
+    "blobGasMaxFee": "13107200",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash008",
+    "blockNumber": 1008,
+    "blockTimestamp": "2023-08-31T16:00:00.000Z",
+    "from": "address2",
+    "hash": "txHash016",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "2883584",
+    "blobGasMaxFee": "13107200",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash006",
+    "blockNumber": 1006,
+    "blockTimestamp": "2023-08-31T12:00:00.000Z",
+    "from": "address5",
+    "hash": "0x5be77167b05f39ea8950f11b0da2bdfec6e04055030068b051ac5a43aaf251e9",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address6",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "2621440",
+    "blobGasMaxFee": "13107200",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "20",
+    },
+    "blockHash": "blockHash005",
+    "blockNumber": 1005,
+    "blockTimestamp": "2023-08-28T10:00:00.000Z",
+    "from": "address5",
+    "hash": "txHash013",
+    "index": 1,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "2883584",
+    "blobGasMaxFee": "13107200",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash003",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash004",
+    "blockNumber": 1004,
+    "blockTimestamp": "2023-08-20T12:00:00.000Z",
+    "from": "address3",
+    "hash": "txHash010",
+    "index": 3,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "2883584",
+    "blobGasMaxFee": "13107200",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash003",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash004",
+    "blockNumber": 1004,
+    "blockTimestamp": "2023-08-20T12:00:00.000Z",
+    "from": "address5",
+    "hash": "txHash009",
+    "index": 2,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address6",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "8650752",
+    "blobGasMaxFee": "39321600",
+    "blobGasUsed": "393216",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+      {
+        "index": 1,
+        "versionedHash": "blobHash001",
+      },
+      {
+        "index": 2,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "from": "address2",
+    "hash": "txHash006",
+    "index": 1,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "8650752",
+    "blobGasMaxFee": "39321600",
+    "blobGasUsed": "393216",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash002",
+      },
+      {
+        "index": 1,
+        "versionedHash": "blobHash002",
+      },
+      {
+        "index": 2,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash003",
+    "blockNumber": 1003,
+    "blockTimestamp": "2023-08-03T12:00:00.000Z",
+    "from": "address2",
+    "hash": "txHash005",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "12100",
+    "blobAsCalldataGasUsed": "1100",
+    "blobGasBaseFee": "2883584",
+    "blobGasMaxFee": "14417920",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "from": "address3",
+    "hash": "txHash002",
+    "index": 1,
+    "maxFeePerBlobGas": "110",
+    "rollup": null,
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "8650752",
+    "blobGasMaxFee": "39321600",
+    "blobGasUsed": "393216",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+      {
+        "index": 1,
+        "versionedHash": "blobHash002",
+      },
+      {
+        "index": 2,
+        "versionedHash": "blobHash003",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "from": "address1",
+    "hash": "txHash001",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": null,
+    "to": "address2",
+  },
+]
+`;
+
 exports[`Transaction router > getAll > when getting filtered transaction results > should return the latest results when no sort was specified 1`] = `
 [
   {
@@ -456,6 +710,131 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "maxFeePerBlobGas": "110",
     "rollup": null,
     "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "14400",
+    "blobAsCalldataGasUsed": "1200",
+    "blobGasBaseFee": "5767168",
+    "blobGasMaxFee": "31457280",
+    "blobGasUsed": "262144",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+      {
+        "index": 1,
+        "versionedHash": "blobHash002",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash001",
+    "blockNumber": 1001,
+    "blockTimestamp": "2022-10-16T12:00:00.000Z",
+    "from": "address5",
+    "hash": "txHash003",
+    "index": 2,
+    "maxFeePerBlobGas": "120",
+    "rollup": "optimism",
+    "to": "address6",
+  },
+]
+`;
+
+exports[`Transaction router > getAll > when getting filtered transaction results > should return the results corresponding to a provided rollup 1`] = `
+[
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "8650752",
+    "blobGasMaxFee": "39321600",
+    "blobGasUsed": "393216",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash004",
+      },
+      {
+        "index": 1,
+        "versionedHash": "blobHash004",
+      },
+      {
+        "index": 2,
+        "versionedHash": "blobHash004",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash007",
+    "blockNumber": 1007,
+    "blockTimestamp": "2023-08-31T14:00:00.000Z",
+    "from": "address5",
+    "hash": "txHash015",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": "optimism",
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "7864320",
+    "blobGasMaxFee": "39321600",
+    "blobGasUsed": "393216",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+      {
+        "index": 1,
+        "versionedHash": "blobHash001",
+      },
+      {
+        "index": 2,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "20",
+    },
+    "blockHash": "blockHash005",
+    "blockNumber": 1005,
+    "blockTimestamp": "2023-08-28T10:00:00.000Z",
+    "from": "address2",
+    "hash": "txHash012",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": "optimism",
+    "to": "address4",
+  },
+  {
+    "blobAsCalldataGasFee": "10000",
+    "blobAsCalldataGasUsed": "1000",
+    "blobGasBaseFee": "2883584",
+    "blobGasMaxFee": "13107200",
+    "blobGasUsed": "131072",
+    "blobs": [
+      {
+        "index": 0,
+        "versionedHash": "blobHash001",
+      },
+    ],
+    "block": {
+      "blobGasPrice": "22",
+    },
+    "blockHash": "blockHash004",
+    "blockNumber": 1004,
+    "blockTimestamp": "2023-08-20T12:00:00.000Z",
+    "from": "address1",
+    "hash": "txHash007",
+    "index": 0,
+    "maxFeePerBlobGas": "100",
+    "rollup": "optimism",
+    "to": "address2",
   },
   {
     "blobAsCalldataGasFee": "14400",
@@ -962,131 +1341,6 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "maxFeePerBlobGas": "100",
     "rollup": null,
     "to": "address2",
-  },
-]
-`;
-
-exports[`Transaction router > getAll > when getting filtered transaction results > should return the results corresponding to the rollup specified 1`] = `
-[
-  {
-    "blobAsCalldataGasFee": "10000",
-    "blobAsCalldataGasUsed": "1000",
-    "blobGasBaseFee": "8650752",
-    "blobGasMaxFee": "39321600",
-    "blobGasUsed": "393216",
-    "blobs": [
-      {
-        "index": 0,
-        "versionedHash": "blobHash004",
-      },
-      {
-        "index": 1,
-        "versionedHash": "blobHash004",
-      },
-      {
-        "index": 2,
-        "versionedHash": "blobHash004",
-      },
-    ],
-    "block": {
-      "blobGasPrice": "22",
-    },
-    "blockHash": "blockHash007",
-    "blockNumber": 1007,
-    "blockTimestamp": "2023-08-31T14:00:00.000Z",
-    "from": "address5",
-    "hash": "txHash015",
-    "index": 0,
-    "maxFeePerBlobGas": "100",
-    "rollup": "optimism",
-    "to": "address4",
-  },
-  {
-    "blobAsCalldataGasFee": "10000",
-    "blobAsCalldataGasUsed": "1000",
-    "blobGasBaseFee": "7864320",
-    "blobGasMaxFee": "39321600",
-    "blobGasUsed": "393216",
-    "blobs": [
-      {
-        "index": 0,
-        "versionedHash": "blobHash001",
-      },
-      {
-        "index": 1,
-        "versionedHash": "blobHash001",
-      },
-      {
-        "index": 2,
-        "versionedHash": "blobHash001",
-      },
-    ],
-    "block": {
-      "blobGasPrice": "20",
-    },
-    "blockHash": "blockHash005",
-    "blockNumber": 1005,
-    "blockTimestamp": "2023-08-28T10:00:00.000Z",
-    "from": "address2",
-    "hash": "txHash012",
-    "index": 0,
-    "maxFeePerBlobGas": "100",
-    "rollup": "optimism",
-    "to": "address4",
-  },
-  {
-    "blobAsCalldataGasFee": "10000",
-    "blobAsCalldataGasUsed": "1000",
-    "blobGasBaseFee": "2883584",
-    "blobGasMaxFee": "13107200",
-    "blobGasUsed": "131072",
-    "blobs": [
-      {
-        "index": 0,
-        "versionedHash": "blobHash001",
-      },
-    ],
-    "block": {
-      "blobGasPrice": "22",
-    },
-    "blockHash": "blockHash004",
-    "blockNumber": 1004,
-    "blockTimestamp": "2023-08-20T12:00:00.000Z",
-    "from": "address1",
-    "hash": "txHash007",
-    "index": 0,
-    "maxFeePerBlobGas": "100",
-    "rollup": "optimism",
-    "to": "address2",
-  },
-  {
-    "blobAsCalldataGasFee": "14400",
-    "blobAsCalldataGasUsed": "1200",
-    "blobGasBaseFee": "5767168",
-    "blobGasMaxFee": "31457280",
-    "blobGasUsed": "262144",
-    "blobs": [
-      {
-        "index": 0,
-        "versionedHash": "blobHash001",
-      },
-      {
-        "index": 1,
-        "versionedHash": "blobHash002",
-      },
-    ],
-    "block": {
-      "blobGasPrice": "22",
-    },
-    "blockHash": "blockHash001",
-    "blockNumber": 1001,
-    "blockTimestamp": "2022-10-16T12:00:00.000Z",
-    "from": "address5",
-    "hash": "txHash003",
-    "index": 2,
-    "maxFeePerBlobGas": "120",
-    "rollup": "optimism",
-    "to": "address6",
   },
 ]
 `;

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -19,7 +19,7 @@ import { DEFAULT_PAGE_LIMIT } from "../src/middlewares/withPagination";
 type TRPCContext = ReturnType<ReturnType<Awaited<typeof createTRPCContext>>>;
 
 type FilterAndPagination = Omit<FiltersSchema, "rollup"> & {
-  rollup?: Lowercase<Rollup>;
+  rollup?: Lowercase<Rollup> | "null";
 } & WithPaginationSchema;
 
 type Entity = "address" | "block" | "transaction" | "blob";
@@ -139,9 +139,17 @@ export function runFiltersTestsSuite(
       expect(result).toMatchSnapshot();
     });
 
-    it("should return the results corresponding to the rollup specified", async () => {
+    it("should return the results corresponding to a provided rollup", async () => {
       const result = await fetcher({
         rollup: "optimism",
+      });
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it("should only return the results that do not have a rollup when 'null' is provided", async () => {
+      const result = await fetcher({
+        rollup: "null",
       });
 
       expect(result).toMatchSnapshot();


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It introduces a new feature that allows to filter entities (blobs, blocks or transactions) that have no `rollup` field set by providing the `null` value.

It resolves #381 

#### Motivation and Context (Optional)
Currently, it's only possible to retrieve entities by a specific rollup or all.

### Related Issue (Optional)

### Screenshots (if appropriate):
