### PR TITLE
feat: make blob proof field mandatory

### DIFF
--- a/.changeset/hip-readers-wait.md
+++ b/.changeset/hip-readers-wait.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": minor
+---
+
+Made `proof` field on `Blob` model mandatory

--- a/.changeset/quick-peas-lay.md
+++ b/.changeset/quick-peas-lay.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": patch
+---
+
+Created index for `proof` field on `Blob` model

--- a/apps/web/src/pages/blob/[hash].tsx
+++ b/apps/web/src/pages/blob/[hash].tsx
@@ -88,15 +88,9 @@ const Blob: NextPage = function () {
     }
     detailsFields.push(
       { name: "Versioned Hash", value: blob.versionedHash },
-      { name: "Commitment", value: blob.commitment }
+      { name: "Commitment", value: blob.commitment },
+      { name: "Proof", value: blob.proof }
     );
-
-    if (blob.proof) {
-      detailsFields.push({
-        name: "Proof",
-        value: blob.proof,
-      });
-    }
 
     detailsFields.push({ name: "Size", value: formatBytes(blob.size) });
 

--- a/packages/api/src/middlewares/withExpands.ts
+++ b/packages/api/src/middlewares/withExpands.ts
@@ -98,7 +98,7 @@ export const serializedExpandedBlockSchema = z.object({
 
 export const serializedExpandedBlobSchema = z.object({
   commitment: z.string().optional(),
-  proof: z.string().nullable().optional(),
+  proof: z.string().optional(),
   size: z.number().optional(),
   dataStorageReferences: z
     .array(serializedBlobDataStorageReferenceSchema)

--- a/packages/api/src/routers/blob/common/serializers.ts
+++ b/packages/api/src/routers/blob/common/serializers.ts
@@ -54,7 +54,7 @@ export type SerializedBlobDataStorageReference = z.infer<
 
 export const serializedBaseBlobSchema = z.object({
   commitment: z.string(),
-  proof: z.string().nullable(),
+  proof: z.string(),
   size: z.number(),
   versionedHash: z.string(),
   data: z.string().optional(),

--- a/packages/db/prisma/migrations/20240716151437_make_blob_proof_field_mandatory/migration.sql
+++ b/packages/db/prisma/migrations/20240716151437_make_blob_proof_field_mandatory/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `proof` on table `blob` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "blob" ALTER COLUMN "proof" SET NOT NULL;

--- a/packages/db/prisma/migrations/20240716152934_create_blob_proof_index/migration.sql
+++ b/packages/db/prisma/migrations/20240716152934_create_blob_proof_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "blob_proof_idx" ON "blob"("proof");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -80,7 +80,7 @@ model Address {
 model Blob {
   versionedHash    String   @id @map("versioned_hash")
   commitment       String   @unique
-  proof            String?
+  proof            String
   size             Int
   firstBlockNumber Int?     @map("first_block_number")
   insertedAt       DateTime @default(now()) @map("inserted_at")

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -89,6 +89,7 @@ model Blob {
   dataStorageReferences BlobDataStorageReference[]
   transactions          BlobsOnTransactions[]
 
+  @@index([proof])
   @@index([insertedAt])
   @@map("blob")
 }

--- a/packages/db/test/extensions/stats-extension.test.fixtures.ts
+++ b/packages/db/test/extensions/stats-extension.test.fixtures.ts
@@ -61,6 +61,7 @@ export const NEW_DATA = {
     {
       versionedHash: "newBlobHash001",
       commitment: "newCommitment001",
+      proof: "newProof001",
       size: 500,
       firstBlockNumber: 2001,
       insertedAt: "2023-09-01T10:00:00Z",
@@ -69,6 +70,7 @@ export const NEW_DATA = {
     {
       versionedHash: "newBlobHash002",
       commitment: "newCommitment002",
+      proof: "newProof002",
       size: 500,
       firstBlockNumber: 2002,
       insertedAt: "2023-09-01T12:00:00Z",


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It makes the blob `proof` field on the `Blob` prisma model mandatory

#### Motivation and Context (Optional)
We have populated this field in all blobscan instances so now we can make mandatory

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
