### PR TITLE
feat(api): add `getBlobDataByBlobId` procedure

### DIFF
--- a/.changeset/strange-pianos-fetch.md
+++ b/.changeset/strange-pianos-fetch.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": minor
+---
+
+Added `getBlobDataByBlobId` procedure

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,8 @@
     "@trpc/server": "^10.43.2",
     "jsonwebtoken": "^9.0.0",
     "superjson": "1.9.1",
-    "trpc-openapi": "^1.2.0"
+    "trpc-openapi": "^1.2.0",
+    "viem": "^2.17.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.2"

--- a/packages/api/src/routers/blob/getBlobDataByBlobId.ts
+++ b/packages/api/src/routers/blob/getBlobDataByBlobId.ts
@@ -1,0 +1,43 @@
+import { z } from "@blobscan/zod";
+
+import { publicProcedure } from "../../procedures";
+import {
+  blobIdSchema,
+  blobVersionedHashSchema,
+  buildVersionedHash,
+  hexSchema,
+  retrieveBlobData,
+} from "../../utils";
+
+const inputSchema = z.object({
+  id: blobIdSchema,
+});
+
+const outputSchema = hexSchema;
+
+export const getBlobDataByBlobId = publicProcedure
+  .meta({
+    openapi: {
+      method: "GET",
+      path: "/blobs/{id}/data",
+      tags: ["blobs"],
+      summary: "Retrives blob data for given blob id.",
+    },
+  })
+  .input(inputSchema)
+  .output(outputSchema)
+  .query(async ({ ctx: { blobStorageManager }, input: { id } }) => {
+    let versionedHash: string;
+
+    if (blobVersionedHashSchema.safeParse(id).success) {
+      versionedHash = id;
+    } else {
+      versionedHash = buildVersionedHash(id);
+    }
+
+    const blobData = await retrieveBlobData(blobStorageManager, {
+      versionedHash,
+    });
+
+    return blobData;
+  });

--- a/packages/api/src/routers/blob/index.ts
+++ b/packages/api/src/routers/blob/index.ts
@@ -1,8 +1,10 @@
 import { t } from "../../trpc-client";
 import { getAll } from "./getAll";
+import { getBlobDataByBlobId } from "./getBlobDataByBlobId";
 import { getByBlobId } from "./getByBlobId";
 
 export const blobRouter = t.router({
   getAll,
   getByBlobId,
+  getBlobDataByBlobId,
 });

--- a/packages/api/src/utils/blob.ts
+++ b/packages/api/src/utils/blob.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import { sha256 } from "viem";
 
 import { BlobStorageManagerError } from "@blobscan/blob-storage-manager";
 import type {
@@ -81,6 +82,12 @@ export function serializeDerivedTxBlobGasFields({
   return serializedFields;
 }
 
+export function buildVersionedHash(commitment: string) {
+  const hashedCommitment = sha256(commitment as `0x${string}`);
+
+  return `0x01${hashedCommitment.slice(4)}`;
+}
+
 export async function retrieveBlobData(
   blobStorageManager: BlobStorageManager,
   {
@@ -121,7 +128,7 @@ export async function retrieveBlobData(
 
   if (versionedHash) {
     blobRetrievalOps.push(() =>
-      blobStorageManager.getBlobByHash(versionedHash).then((res) => res.data)
+      blobStorageManager.getBlobByHash(versionedHash).then(({ data }) => data)
     );
   }
 

--- a/packages/api/src/utils/schemas.ts
+++ b/packages/api/src/utils/schemas.ts
@@ -89,6 +89,54 @@ export const slotSchema = z.number().nonnegative();
 
 export const blobIndexSchema = z.number().nonnegative();
 
+export const hexSchema = z.string().regex(/^0x[0-9a-fA-F]+$/, {
+  message: "Invalid hexadecimal string",
+});
+
 export const addressSchema = z
   .string()
   .transform((value) => value.toLowerCase());
+
+export const blobVersionedHashSchema = hexSchema.length(66).startsWith("0x01");
+
+export const blobCommitmentSchema = hexSchema.length(98);
+
+export const blobIdSchema = z
+  .string()
+  .superRefine((val, ctx) => {
+    if (!hexSchema.safeParse(val).success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_string,
+        message: "Invalid input: must be a valid hex string",
+        validation: "regex",
+        fatal: true,
+      });
+
+      return z.NEVER;
+    }
+
+    if (val.length !== 66 && val.length !== 98) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Invalid input length: must be a versioned hash (32 bytes) or a kzg commitment (48 bytes)",
+        fatal: true,
+      });
+
+      return z.NEVER;
+    }
+
+    if (val.length === 66 && !val.startsWith("0x01")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_string,
+        message: 'Invalid versioned hash: must start with "0x01"',
+        validation: "regex",
+        fatal: true,
+      });
+
+      return z.NEVER;
+    }
+  })
+  .describe(
+    "Blob identifier. It can be the blob's versioned hash or kzg commitment."
+  );

--- a/packages/api/test/__snapshots__/blob.test.ts.snap
+++ b/packages/api/test/__snapshots__/blob.test.ts.snap
@@ -2650,6 +2650,47 @@ exports[`Blob router > getAll > when getting paginated blob results > should ret
 ]
 `;
 
+exports[`Blob router > getBlobDataByBlobId > when providing an invalid blob id > should fail when providing a hex string with invalid length 1`] = `
+"[
+  {
+    \\"code\\": \\"custom\\",
+    \\"message\\": \\"Invalid input length: must be a versioned hash (32 bytes) or a kzg commitment (48 bytes)\\",
+    \\"fatal\\": true,
+    \\"path\\": [
+      \\"id\\"
+    ]
+  }
+]"
+`;
+
+exports[`Blob router > getBlobDataByBlobId > when providing an invalid blob id > should fail when providing a non-hex string 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_string\\",
+    \\"message\\": \\"Invalid input: must be a valid hex string\\",
+    \\"validation\\": \\"regex\\",
+    \\"fatal\\": true,
+    \\"path\\": [
+      \\"id\\"
+    ]
+  }
+]"
+`;
+
+exports[`Blob router > getBlobDataByBlobId > when providing an invalid blob id > should fail when providing a versioned hash with invalid prefix 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_string\\",
+    \\"message\\": \\"Invalid versioned hash: must start with \\\\\\"0x01\\\\\\"\\",
+    \\"validation\\": \\"regex\\",
+    \\"fatal\\": true,
+    \\"path\\": [
+      \\"id\\"
+    ]
+  }
+]"
+`;
+
 exports[`Blob router > getByBlobId > should fail when getting a blob and the blob data is not available 1`] = `[TRPCError: Failed to get blob from any of the storages]`;
 
 exports[`Blob router > getByBlobId > should fail when trying to get a blob by a non-existent hash 1`] = `[TRPCError: No blob with versioned hash or kzg commitment 'nonExistingHash'.]`;

--- a/packages/api/test/test-suites/schemas.ts
+++ b/packages/api/test/test-suites/schemas.ts
@@ -1,0 +1,36 @@
+import { TRPCError } from "@trpc/server";
+import { describe } from "vitest";
+
+import { testValidError } from "@blobscan/test";
+
+export function blobIdSchemaTestsSuite(
+  fetcher: (invalidBlobId: string) => Promise<unknown>
+) {
+  return describe("when providing an invalid blob id", () => {
+    testValidError(
+      "should fail when providing a non-hex string",
+      async () => {
+        await fetcher("nonHexString");
+      },
+      TRPCError
+    );
+
+    testValidError(
+      "should fail when providing a hex string with invalid length",
+      async () => {
+        await fetcher("0x123");
+      },
+      TRPCError
+    );
+
+    testValidError(
+      "should fail when providing a versioned hash with invalid prefix",
+      async () => {
+        await fetcher(
+          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        );
+      },
+      TRPCError
+    );
+  });
+}

--- a/packages/db/test/extensions/stats-extension.test.ts
+++ b/packages/db/test/extensions/stats-extension.test.ts
@@ -244,7 +244,7 @@ describe("Stats Extension", () => {
 
     runOverallStatsFunctionsTests("blobOverallStats", {
       statsCalculationTestsSuite() {
-        let blobOverallStats: BlobOverallStats | null;
+        let blobOverallStats: BlobOverallStats;
 
         beforeEach(async () => {
           await prisma.blobOverallStats.increment({
@@ -252,7 +252,7 @@ describe("Stats Extension", () => {
             to: 9999,
           });
 
-          blobOverallStats = await prisma.blobOverallStats.findFirst();
+          blobOverallStats = await prisma.blobOverallStats.findFirstOrThrow();
 
           return async () => {
             await prisma.blobOverallStats.deleteMany();
@@ -268,7 +268,7 @@ describe("Stats Extension", () => {
         it("should calculate the total amount of unique blobs correctly", async () => {
           const expectedTotalUniqueBlobs = fixtures.canonicalUniqueBlobs.length;
 
-          expect(blobOverallStats?.totalUniqueBlobs).toBe(
+          expect(blobOverallStats?.totalUniqueBlobs + 1).toBe(
             expectedTotalUniqueBlobs
           );
         });

--- a/packages/test/src/fixtures/index.ts
+++ b/packages/test/src/fixtures/index.ts
@@ -16,10 +16,11 @@ export const fixtures = {
   blobs: POSTGRES_DATA.blobs,
   blobDataStorageRefs:
     POSTGRES_DATA.blobDataStorageReferences as BlobDataStorageReference[],
-  blobDatas: POSTGRES_DATA.blobDatas.map<BlobData>((blobData) => ({
-    id: blobData.id,
-    data: Buffer.from(blobData.data, "hex"),
+  blobDatas: POSTGRES_DATA.blobDatas.map<BlobData>(({ data: rawData, id }) => ({
+    id,
+    data: Buffer.from(rawData, "hex"),
   })),
+
   blobsOnTransactions: POSTGRES_DATA.blobsOnTransactions,
   systemDate: POSTGRES_DATA.systemDate,
 

--- a/packages/test/src/fixtures/postgres/data.json
+++ b/packages/test/src/fixtures/postgres/data.json
@@ -453,6 +453,12 @@
       "commitment": "0x89e6ebcf42d04b1d09f54aa731fd3a2f1df95bd45ba488f28f7e72842a6ea547570d446391c627d4341a1ec922feb529",
       "proof": "0xaf8b65d906c672d670d3d9591ede355ac4dfc2f66f5690e836018fdb8582d3055474e3de6a069d3dfb4c15aa7c7f88a6",
       "size": 128000
+    },
+    {
+      "versionedHash": "0x01f433be851da7e34bf14bf4f21b4c7db4b38afee7ec74d3c576fdce9f8f6734",
+      "commitment": "0x8c5b4383c1db58dc3f615ee8a1fdeb2a1ad19d1f26d72119c23b36b5df30ea4be9d55ccb9254f7a7993d23a78bd858ce",
+      "proof": "0x992c686396169cb1d4b19cbd77db2b9c8a4ad702419285b1e35288c496225c43c9d17abe669bd63b858832c40321e39e",
+      "size": 128000
     }
   ],
   "addresses": [
@@ -559,6 +565,11 @@
       "blobHash": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436",
       "blobStorage": "POSTGRES",
       "dataReference": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436"
+    },
+    {
+      "blobHash": "0x01f433be851da7e34bf14bf4f21b4c7db4b38afee7ec74d3c576fdce9f8f6734",
+      "blobStorage": "POSTGRES",
+      "dataReference": "0x01f433be851da7e34bf14bf4f21b4c7db4b38afee7ec74d3c576fdce9f8f6734"
     }
   ],
   "blobDatas": [
@@ -580,7 +591,11 @@
     },
     {
       "id": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436",
-      "data": "0x2fba0bd756009b29dc26256c2203dd2d5d3176779560683a8c6daff73ca1c418"
+      "data": "2fba0bd756009b29dc26256c2203dd2d5d3176779560683a8c6daff73ca1c4181"
+    },
+    {
+      "id": "0x01f433be851da7e34bf14bf4f21b4c7db4b38afee7ec74d3c576fdce9f8f6734",
+      "data": "cc4d7802def45b483ffedd310430bacf929d0160261691dd9cdecfdb6d920586991bd058e7d25020"
     }
   ],
   "blobsOnTransactions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       trpc-openapi:
         specifier: ^1.2.0
         version: 1.2.0(@trpc/server@10.45.2)(zod@3.23.5)
+      viem:
+        specifier: ^2.17.4
+        version: 2.17.4(typescript@5.4.5)(zod@3.23.5)
     devDependencies:
       '@types/jsonwebtoken':
         specifier: ^9.0.2
@@ -729,6 +732,9 @@ packages:
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@adraffy/ens-normalize@1.10.0':
+    resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
 
   '@algolia/autocomplete-core@1.17.0':
     resolution: {integrity: sha512-6E4sVb5+fGtSQs9mULlxUH84OWFUVZPMapa5dMCtUc7KyDRLY6+X/dA8xbDA8CX5phdBn1plLUET1B6NZnrZuw==}
@@ -2122,6 +2128,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/curves@1.4.0':
+    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
+
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2559,6 +2572,15 @@ packages:
 
   '@rushstack/eslint-patch@1.5.1':
     resolution: {integrity: sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==}
+
+  '@scure/base@1.1.7':
+    resolution: {integrity: sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==}
+
+  '@scure/bip32@1.4.0':
+    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
+
+  '@scure/bip39@1.3.0':
+    resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
 
   '@sentry-internal/feedback@7.112.2':
     resolution: {integrity: sha512-z+XP8BwB8B3pa+i8xqbrPsbtDWUFUS6wo+FJbmOYUqOusJJbVFDAhBoEdKoo5ZjOcsAZG7XR6cA9zrhJynIWBA==}
@@ -3105,6 +3127,17 @@ packages:
 
   '@vitest/utils@0.34.7':
     resolution: {integrity: sha512-ziAavQLpCYS9sLOorGrFFKmy2gnfiNU0ZJ15TsMz/K92NAPS/rp9K4z6AJQQk5Y8adCy4Iwpxy7pQumQ/psnRg==}
+
+  abitype@1.0.5:
+    resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4744,6 +4777,11 @@ packages:
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+
+  isows@1.0.4:
+    resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
     peerDependencies:
       ws: '*'
 
@@ -6626,6 +6664,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  viem@2.17.4:
+    resolution: {integrity: sha512-6gmBB85I7z1qt/+yPPS+i4L2jNPJqCs+SEb+26WnKVYez13svSzjYMsU9OYYlPFpQmpGSy9dV2bKW6VX68FTgg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@0.34.6:
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
@@ -6816,6 +6862,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xorshift@1.2.0:
     resolution: {integrity: sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g==}
 
@@ -6891,6 +6949,8 @@ snapshots:
       typical: 7.1.1
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
+
+  '@adraffy/ens-normalize@1.10.0': {}
 
   '@algolia/autocomplete-core@1.17.0(@algolia/client-search@4.23.3)(algoliasearch@4.23.3)(search-insights@2.13.0)':
     dependencies:
@@ -8657,6 +8717,12 @@ snapshots:
   '@next/swc-win32-x64-msvc@13.5.6':
     optional: true
 
+  '@noble/curves@1.4.0':
+    dependencies:
+      '@noble/hashes': 1.4.0
+
+  '@noble/hashes@1.4.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9129,6 +9195,19 @@ snapshots:
     optional: true
 
   '@rushstack/eslint-patch@1.5.1': {}
+
+  '@scure/base@1.1.7': {}
+
+  '@scure/bip32@1.4.0':
+    dependencies:
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.7
+
+  '@scure/bip39@1.3.0':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.7
 
   '@sentry-internal/feedback@7.112.2':
     dependencies:
@@ -9805,6 +9884,11 @@ snapshots:
       diff-sequences: 29.6.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  abitype@1.0.5(typescript@5.4.5)(zod@3.23.5):
+    optionalDependencies:
+      typescript: 5.4.5
+      zod: 3.23.5
 
   abort-controller@3.0.0:
     dependencies:
@@ -11779,6 +11863,10 @@ snapshots:
   isomorphic-ws@4.0.1(ws@8.14.2):
     dependencies:
       ws: 8.14.2
+
+  isows@1.0.4(ws@8.17.1):
+    dependencies:
+      ws: 8.17.1
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -13765,6 +13853,23 @@ snapshots:
 
   vary@1.1.2: {}
 
+  viem@2.17.4(typescript@5.4.5)(zod@3.23.5):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+      abitype: 1.0.5(typescript@5.4.5)(zod@3.23.5)
+      isows: 1.0.4(ws@8.17.1)
+      ws: 8.17.1
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@0.34.6(@types/node@18.19.31):
     dependencies:
       cac: 6.7.14
@@ -13973,6 +14078,8 @@ snapshots:
   ws@7.5.9: {}
 
   ws@8.14.2: {}
+
+  ws@8.17.1: {}
 
   xorshift@1.2.0: {}
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It adds a new procedure to the api to retrieve the blob data given a blob identifier which can be a blob's versioned hash or kzg commitment.

### Motivation and Context (Optional)
This PR is related to #446.  By implementing an OpenAPI-supported procedure to retrieve blob data, the API can now return URLs for retrieving blob data from internal storage systems such as Postgres or the file system, alongside other blob data references when retrieving a single blob or a series of blobs.

### Related Issue (Optional)

### Screenshots (if appropriate):
