### PR TITLE
feat(web): replace list of `TransactionCard` by new `PaginatedTable` on the transactions view

### DIFF
--- a/.changeset/tiny-dancers-live.md
+++ b/.changeset/tiny-dancers-live.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Replaced list of TransactionCards by new PaginatedTable on the transactions view

--- a/apps/web/src/components/Table/index.tsx
+++ b/apps/web/src/components/Table/index.tsx
@@ -86,7 +86,7 @@ export const Table: FC<TableProps> = function ({
                           ) => (
                             <Fragment key={i}>
                               {Boolean(expandableRowsMode && i === 0) && (
-                                <TableHeader className="sr-only w-16" />
+                                <TableHeader className="sr-only w-12" />
                               )}
                               <TableHeader
                                 className={`${generalHeaderStyles} ${specificHeaderStyles} truncate`}

--- a/apps/web/src/pages/txs.tsx
+++ b/apps/web/src/pages/txs.tsx
@@ -3,18 +3,89 @@ import type { NextPage } from "next";
 import { useRouter } from "next/router";
 
 import { getPaginationParams } from "~/utils/pagination";
-import { BlobTransactionCard } from "~/components/Cards/SurfaceCards/BlobTransactionCard";
-import { PaginatedListLayout } from "~/components/Layouts/PaginatedListLayout";
+import { EtherUnitDisplay } from "~/components/Displays/EtherUnitDisplay";
+import { Link } from "~/components/Link";
+import { PaginatedTable } from "~/components/PaginatedTable/PaginatedTable";
+import { RollupIcon } from "~/components/RollupIcon";
+import { Table } from "~/components/Table";
 import { api } from "~/api-client";
 import NextError from "~/pages/_error";
 import type { TransactionWithExpandedBlockAndBlob } from "~/types";
-import { deserializeFullTransaction, formatNumber } from "~/utils";
+import type { DeserializedBlob, DeserializedFullTransaction } from "~/utils";
+import {
+  buildAddressRoute,
+  buildBlockRoute,
+  buildTransactionRoute,
+  formatBytes,
+  formatNumber,
+  formatTimestamp,
+  shortenAddress,
+  deserializeFullTransaction,
+  buildBlobRoute,
+} from "~/utils";
+
+export const TRANSACTIONS_TABLE_HEADERS = [
+  {
+    cells: [
+      {
+        item: "Hash",
+      },
+      {
+        item: "Block number",
+      },
+      {
+        item: "Timestamp",
+      },
+      {
+        item: "From",
+      },
+      {
+        item: "To",
+      },
+      {
+        item: "Rollup",
+      },
+      {
+        item: "Blob Base Fee",
+      },
+      {
+        item: "Blob Max Fee",
+      },
+      {
+        item: "Blob Gas Price",
+      },
+    ],
+  },
+];
+
+const TRANSACTIONS_TABLE_DEFAULT_PAGE_SIZE = 50;
+
+type Transaction = Pick<
+  DeserializedFullTransaction,
+  | "hash"
+  | "from"
+  | "to"
+  | "blobs"
+  | "rollup"
+  | "blockNumber"
+  | "blobGasBaseFee"
+  | "blobGasMaxFee"
+  | "block"
+  | "blockTimestamp"
+> & { blobsLength?: number };
 
 const Txs: NextPage = function () {
   const router = useRouter();
-  const { p, ps } = getPaginationParams(router.query);
+  const { p, ps } = getPaginationParams(
+    router.query,
+    TRANSACTIONS_TABLE_DEFAULT_PAGE_SIZE
+  );
 
-  const { data: rawTxsData, error } = api.tx.getAll.useQuery<{
+  const {
+    data: rawTxsData,
+    isLoading,
+    error,
+  } = api.tx.getAll.useQuery<{
     transactions: TransactionWithExpandedBlockAndBlob[];
     totalTransactions: number;
   }>({
@@ -34,6 +105,150 @@ const Txs: NextPage = function () {
   }, [rawTxsData]);
   const { transactions, totalTransactions } = txsData || {};
 
+  const transactionRows = useMemo(() => {
+    return transactions
+      ? transactions.map((t: Transaction) => {
+          const {
+            hash,
+            from,
+            to,
+            blobs,
+            rollup,
+            blockNumber,
+            blobGasBaseFee,
+            blobGasMaxFee,
+            block,
+            blockTimestamp,
+          } = t;
+
+          const getTransactionsTableRowExpandItem = (
+            blobs?: Pick<
+              DeserializedBlob,
+              | "versionedHash"
+              | "commitment"
+              | "size"
+              | "dataStorageReferences"
+              | "proof"
+            >[]
+          ) => {
+            const headers = [
+              {
+                cells: [
+                  {
+                    item: "Blob Versioned Hash",
+                  },
+                  {
+                    item: "Size",
+                  },
+                ],
+                className: "dark:border-border-dark/20",
+                sticky: true,
+              },
+            ];
+
+            const rows = blobs
+              ? blobs.map((b) => ({
+                  cells: [
+                    {
+                      item: (
+                        <Link href={buildBlobRoute(b.versionedHash)}>
+                          {b.versionedHash}
+                        </Link>
+                      ),
+                    },
+                    {
+                      item: (
+                        <div className="flex gap-2">
+                          <span>{formatBytes(b.size)}</span>
+                        </div>
+                      ),
+                    },
+                  ],
+                  className: "dark:border-border-dark/10",
+                }))
+              : undefined;
+
+            return (
+              <Table
+                className="mb-4 mt-2 max-h-[420px] rounded-lg bg-primary-50 px-8 dark:bg-primary-800"
+                size="xs"
+                alignment="left"
+                variant="transparent"
+                headers={headers}
+                rows={rows}
+              />
+            );
+          };
+
+          return {
+            cells: [
+              {
+                item: (
+                  <Link href={buildTransactionRoute(hash)}>
+                    {shortenAddress(hash, 6)}
+                  </Link>
+                ),
+              },
+              {
+                item: (
+                  <Link href={buildBlockRoute(blockNumber)}>{blockNumber}</Link>
+                ),
+              },
+              {
+                item: (
+                  <div className="whitespace-break-spaces">
+                    {formatTimestamp(blockTimestamp, true)}
+                  </div>
+                ),
+              },
+              {
+                item: (
+                  <Link href={buildAddressRoute(from)}>
+                    {shortenAddress(from, 6)}
+                  </Link>
+                ),
+              },
+              {
+                item: (
+                  <Link href={buildAddressRoute(to)}>
+                    {shortenAddress(to, 6)}
+                  </Link>
+                ),
+              },
+              {
+                item: rollup ? <RollupIcon rollup={rollup} /> : <></>,
+              },
+              {
+                item: (
+                  <div className="truncate">
+                    <EtherUnitDisplay amount={blobGasBaseFee} toUnit="Gwei" />
+                  </div>
+                ),
+              },
+              {
+                item: (
+                  <div className="truncate">
+                    <EtherUnitDisplay amount={blobGasMaxFee} toUnit="Gwei" />
+                  </div>
+                ),
+              },
+              {
+                item: (
+                  <div className="truncate">
+                    <EtherUnitDisplay
+                      amount={block.blobGasPrice}
+                      toUnit="Gwei"
+                    />
+                  </div>
+                ),
+              },
+            ],
+            expandItem: getTransactionsTableRowExpandItem(blobs),
+          };
+        })
+      : undefined;
+  }, [transactions]);
+
   if (error) {
     return (
       <NextError
@@ -44,18 +259,16 @@ const Txs: NextPage = function () {
   }
 
   return (
-    <PaginatedListLayout
-      header={`Blob Transactions ${
+    <PaginatedTable
+      title={`Blob Transactions ${
         totalTransactions ? `(${formatNumber(totalTransactions)})` : ""
       }`}
-      items={transactions?.map((tx) => (
-        <BlobTransactionCard key={tx.hash} transaction={tx} blobs={tx.blobs} />
-      ))}
-      totalItems={totalTransactions}
-      page={p}
-      pageSize={ps}
-      itemSkeleton={<BlobTransactionCard />}
-      emptyState="No blob transactions"
+      isLoading={isLoading}
+      headers={TRANSACTIONS_TABLE_HEADERS}
+      rows={transactionRows}
+      totalItems={totalTransactions || 0}
+      paginationData={{ pageSize: ps, page: p }}
+      isExpandable
     />
   );
 };

--- a/apps/web/src/pages/txs.tsx
+++ b/apps/web/src/pages/txs.tsx
@@ -61,7 +61,7 @@ export const TRANSACTIONS_TABLE_HEADERS = [
       },
       {
         item: "Blob Gas Price",
-        className: "w-[180px]",
+        className: "2xl:w-full w-[180px]",
       },
     ],
   },

--- a/apps/web/src/pages/txs.tsx
+++ b/apps/web/src/pages/txs.tsx
@@ -29,30 +29,39 @@ export const TRANSACTIONS_TABLE_HEADERS = [
     cells: [
       {
         item: "Hash",
+        className: "w-[150px]",
       },
       {
         item: "Block number",
+        className: "w-[127px]",
       },
       {
         item: "Timestamp",
+        className: "w-[160px]",
       },
       {
         item: "From",
+        className: "w-[150px]",
       },
       {
         item: "To",
+        className: "w-[148px]",
       },
       {
         item: "Rollup",
+        className: "w-[72px]",
       },
       {
         item: "Blob Base Fee",
+        className: "w-[172px]",
       },
       {
         item: "Blob Max Fee",
+        className: "w-[162px]",
       },
       {
         item: "Blob Gas Price",
+        className: "w-[180px]",
       },
     ],
   },
@@ -266,7 +275,7 @@ const Txs: NextPage = function () {
       isLoading={isLoading}
       headers={TRANSACTIONS_TABLE_HEADERS}
       rows={transactionRows}
-      totalItems={totalTransactions || 0}
+      totalItems={totalTransactions}
       paginationData={{ pageSize: ps, page: p }}
       isExpandable
     />


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

It resolves #451

Migrate the current 'transaction view' using a transaction card list to the new `PaginatedTable` component

### Screenshots 

![image](https://github.com/user-attachments/assets/ebca624e-bc08-448c-b15c-c945d2ac5b26)