### PR TITLE
refactor: Remove BigIntLike

### DIFF
--- a/apps/web/src/utils/ethereum.ts
+++ b/apps/web/src/utils/ethereum.ts
@@ -1,4 +1,9 @@
-import { calculatePercentage, formatNumber, performDiv } from "./number";
+import {
+  calculatePercentage,
+  formatNumber,
+  numberToBigInt,
+  performDiv,
+} from "./number";
 
 export const GAS_PER_BLOB = 131_072; // 2 ** 17
 export const BLOB_SIZE = GAS_PER_BLOB;
@@ -62,12 +67,16 @@ export function convertWei(
 
 export function calculateBlobGasTarget(blobGasUsed: bigint) {
   const blobsInBlock = performDiv(blobGasUsed, BigInt(GAS_PER_BLOB));
+
   const targetPercentage =
     blobsInBlock < TARGET_BLOBS_PER_BLOCK
-      ? calculatePercentage(blobsInBlock, TARGET_BLOBS_PER_BLOCK)
+      ? calculatePercentage(
+          numberToBigInt(blobsInBlock),
+          numberToBigInt(TARGET_BLOBS_PER_BLOCK)
+        )
       : calculatePercentage(
-          blobsInBlock - TARGET_BLOBS_PER_BLOCK,
-          TARGET_BLOBS_PER_BLOCK
+          numberToBigInt(blobsInBlock - TARGET_BLOBS_PER_BLOCK),
+          numberToBigInt(TARGET_BLOBS_PER_BLOCK)
         );
 
   return targetPercentage;

--- a/apps/web/src/utils/number.ts
+++ b/apps/web/src/utils/number.ts
@@ -3,7 +3,13 @@ import prettyBytes from "pretty-bytes";
 
 type FormatMode = "compact" | "standard";
 
-export type BigIntLike = bigint | number | string;
+export function numberToBigInt(value: number): bigint {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return BigInt(0);
+  }
+
+  return BigInt(Math.round(value));
+}
 
 const NUMBER_FORMAT: Record<FormatMode, Intl.NumberFormatOptions> = {
   compact: {
@@ -34,16 +40,13 @@ export function abbreviateNumber(value: number | string): string {
   }).format(Number(value));
 }
 
-export function performDiv(a: BigIntLike, b: BigIntLike, precision = 16) {
-  const a_ = BigInt(a);
-  const b_ = BigInt(b);
-
-  if (b_ === BigInt(0)) {
+export function performDiv(a: bigint, b: bigint, precision = 16) {
+  if (b === BigInt(0)) {
     throw new Error("Division by zero");
   }
 
   const scaleFactor = 10 ** precision;
-  const scaledResult = (a_ * BigInt(scaleFactor)) / b_;
+  const scaledResult = (a * BigInt(scaleFactor)) / b;
 
   return Number(scaledResult) / scaleFactor;
 }
@@ -59,18 +62,15 @@ export function formatNumber(
 }
 
 export function calculatePercentage(
-  numerator: BigIntLike,
-  denominator: BigIntLike,
+  numerator: bigint,
+  denominator: bigint,
   opts?: Partial<{ returnComplement: boolean }>
 ): number {
-  const num = BigInt(numerator);
-  const denom = BigInt(denominator);
-
-  if (denom === BigInt(0)) {
-    return Number(0);
+  if (denominator === BigInt(0)) {
+    return 0;
   }
 
-  const pct = performDiv(num, denom) * 100;
+  const pct = performDiv(numerator, denominator) * 100;
 
   if (opts?.returnComplement) {
     return 100 - pct;


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->
This change addresses an error in the `calculatePercentage` function that occurred when using synthetic data generated by the data generator. The error message was:
```RangeError: The number 21460778973.687706 cannot be converted to a BigInt because it is not an integer```

To resolve this issue, I made the following changes:
1. Updated functions that previously accepted `BigIntLike` parameters to exclusively accept `bigint`.
2. Removed the `BigIntLike` type entirely from the codebase.
3. Added `numberToBigInt`

These modifications ensure type consistency and prevent potential conversion errors when working with large numbers.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

This function takes two `BigIntLike`. Initially, I considered implementing a more robust conversion, which would have introduced some overhead. However, upon further review, I noticed that the function was only being used with `bigint`, except for one instance where we used a number, which is the same place where the original error occurred.

To address this, I updated the only two functions that took `BigIntLike` as a parameter to take `bigint` exclusively and removed the `BigIntLike` type altogether.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/929dbf78-73eb-4879-a048-f86ab023ec62)
