### PR TITLE
fix: Fix search

### DIFF
--- a/apps/web/src/pages/search.tsx
+++ b/apps/web/src/pages/search.tsx
@@ -1,7 +1,7 @@
 import type { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 
-import { searchByTerm } from "@blobscan/api/src/routers/search/byTerm";
+import { searchByTerm } from "@blobscan/api";
 
 import { Button } from "~/components/Button";
 import type { RouterOutputs } from "~/api-client";

--- a/apps/web/src/pages/search.tsx
+++ b/apps/web/src/pages/search.tsx
@@ -1,10 +1,7 @@
 import type { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
-import { createServerSideHelpers } from "@trpc/react-query/server";
-import superjson from "superjson";
 
-import type { TRPCContext } from "@blobscan/api";
-import { appRouter, createTRPCInnerContext } from "@blobscan/api";
+import { searchByTerm } from "@blobscan/api/src/routers/search/byTerm";
 
 import { Button } from "~/components/Button";
 import type { RouterOutputs } from "~/api-client";
@@ -19,12 +16,6 @@ type SearchProps = {
 
 export const getServerSideProps: GetServerSideProps<SearchProps> =
   async function ({ query }) {
-    const ctx = (await createTRPCInnerContext()) as TRPCContext;
-    const helpers = createServerSideHelpers({
-      router: appRouter,
-      ctx,
-      transformer: superjson,
-    });
     const term = query.q as string | undefined;
 
     if (!term) {
@@ -35,7 +26,7 @@ export const getServerSideProps: GetServerSideProps<SearchProps> =
       };
     }
 
-    const searchResults = await helpers.search.byTerm.fetch({ term });
+    const searchResults = await searchByTerm(term);
     const categories = Object.keys(searchResults) as SearchCategory[];
 
     if (categories.length === 0) {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -23,6 +23,8 @@ export type {
   MetricsClient,
 } from "@blobscan/db";
 
+export { searchByTerm } from "./routers/search/byTerm";
+
 /**
  * Inference helpers for input types
  * @example type HelloInput = RouterInputs['example']['hello']

--- a/packages/api/src/routers/search/byTerm.schema.ts
+++ b/packages/api/src/routers/search/byTerm.schema.ts
@@ -1,5 +1,0 @@
-import { z } from "@blobscan/zod";
-
-export const byTermInputSchema = z.object({
-  term: z.string(),
-});


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->
The search bar currently only works if the suggestions are loaded. If the suggestions aren't loaded and you press the `enter` key, you'll be redirected to an error 500 page after a few seconds.

The problem occurred because an invalid `trpc context` was being created inside `getServerSideProps` in the `search.tsx` file.

As we are already on the server, there is no need to recreate a `trpc helper` each time someone visits `\search`. We can simply call the search function directly. To achieve this, I refactored the search functionality out of the `trpc query` so that we can use the search function both inside and outside the query.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->
https://github.com/Blobscan/blobscan/issues/66#issuecomment-2057009689

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/2c72b093-c643-4a09-bcec-b3e3c04459b5)
If you are on the main branch and you try to search for something, you will encounter this error. This error occurs inside the `withTelemetry` middleware. You might initially think it's unrelated to the search, but the issue actually stems from the middleware utilizing undefined data due to the `trpc context` being incorrectly defined inside the `getServerSideProps`.