### PR TITLE
Make SWARM_DEFERRED_UPLOAD default to true

### DIFF
--- a/apps/docs/src/app/docs/environment/page.md
+++ b/apps/docs/src/app/docs/environment/page.md
@@ -49,7 +49,7 @@ nextjs:
 | `GOOGLE_STORAGE_BUCKET_NAME`         | Google Cloud Storage bucket name                                                                   | No                              | (empty)                    |
 | `GOOGLE_STORAGE_PROJECT_ID`          | Google Cloud project ID                                                                            | No                              | (empty)                    |
 | `POSTGRES_STORAGE_ENABLED`           | Store blobs in postgres database (default storage)                                                 | No                              | `false`                    |
-| `SWARM_DEFERRED_UPLOAD`              | Determines if the uploaded data should be sent to the network immediately or in a deferred fashion | No                              | false                      |
+| `SWARM_DEFERRED_UPLOAD`              | Determines if the uploaded data should be sent to the network immediately or in a deferred fashion | No                              | `true`                     |
 | `SWARM_STORAGE_ENABLED`              | Store blobs in Ethereum Swarm                                                                      | No                              | `false`                    |
 | `SWARM_BATCH_ID`                     | Batch ID of the Ethereum Swarm stamp                                                               | If `SWARM_STORAGE_ENABLED=true` | (empty)                    |
 | `BEE_ENDPOINT`                       | Bee endpoint                                                                                       | No                              | (empty)                    |

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -78,7 +78,7 @@ export const env = createEnv({
       SECRET_KEY: z.string(),
       SENTRY_DSN_API: z.string().optional(),
       SWARM_STORAGE_ENABLED: booleanSchema.default("false"),
-      SWARM_DEFERRED_UPLOAD: booleanSchema.default("false"),
+      SWARM_DEFERRED_UPLOAD: booleanSchema.default("true"),
       SWARM_STAMP_CRON_PATTERN: z.string().default("*/15 * * * *"),
       SWARM_BATCH_ID: z.string().optional(),
       TEST: booleanSchema.optional(),


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Change default value for the SWARM_DEFERRED_UPLOAD variable.

#### Motivation and Context (Optional)

We had some problems in the past with the swarm bee client and deferred uploads, so we set it to False. It looks like these issues are gone since the bee v2.0.0 release so it is safe to set it back to true by default. It is also required in order to keep the swarm storage in sync with the blobs that are processed.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
