### PR TITLE
fix: 'Display Items' dropdown in `PaginatedTable` change not working

### DIFF
--- a/.changeset/seven-gorillas-deny.md
+++ b/.changeset/seven-gorillas-deny.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed 'Displayed Items' dropdown in PaginedTable

--- a/apps/web/src/utils/pagination.ts
+++ b/apps/web/src/utils/pagination.ts
@@ -1,10 +1,10 @@
 import type { ParsedUrlQuery } from "querystring";
 
-const DEFAULT_PAGE_SIZE = 25;
+const DEFAULT_INITIAL_PAGE_SIZE = 25;
 
 export function getPaginationParams(
   query: ParsedUrlQuery,
-  customPageSize?: number
+  initialPageSize = DEFAULT_INITIAL_PAGE_SIZE
 ): {
   ps: number;
   p: number;
@@ -12,7 +12,7 @@ export function getPaginationParams(
   const page_ = parseInt(query.p as string);
   const pageSize_ = parseInt(query.ps as string);
   const page = isNaN(page_) ? 1 : page_;
-  const pageSize = isNaN(pageSize_) ? DEFAULT_PAGE_SIZE : pageSize_;
+  const pageSize = isNaN(pageSize_) ? initialPageSize : pageSize_;
 
-  return { ps: customPageSize ? customPageSize : pageSize, p: page };
+  return { ps: pageSize, p: page };
 }


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

The dropdown change doesn't update the table page size in the new `<PaginatedTable />` component as a bug introduced in `patination` utils
