### PR TITLE
Fix metrics display overflow

### DIFF
--- a/.changeset/witty-steaks-rest.md
+++ b/.changeset/witty-steaks-rest.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Resolved homepage metrics display overflow issue

--- a/apps/web/src/components/Cards/MetricCard.tsx
+++ b/apps/web/src/components/Cards/MetricCard.tsx
@@ -107,7 +107,7 @@ function MetricLayout({
     <div
       className={cn(
         {
-          "text-lg sm:text-xl": compact,
+          "text-lg sm:text-xl lg:text-sm xl:text-xl": compact,
           "text-lg lg:text-2xl": !compact,
         },
         {
@@ -205,7 +205,8 @@ export const MetricCard: FC<MetricCardProps> = function ({
             "sm:gap-4": !compact,
             "sm:gap-1": compact,
           },
-          "flex flex-col justify-between gap-1"
+          "flex flex-col justify-between gap-1",
+          "relative overflow-hidden"
         )}
       >
         <div

--- a/apps/web/src/components/Cards/MetricCard.tsx
+++ b/apps/web/src/components/Cards/MetricCard.tsx
@@ -80,7 +80,7 @@ function formatMetric(
       break;
     default:
       formattedValue = formatNumber(value, mode, {
-        maximumSignificantDigits: 9,
+        maximumSignificantDigits: 2,
         ...numberFormatOpts,
       });
       break;


### PR DESCRIPTION
### Description
Resolved homepage metrics display overflow issue

### Related Issue
Closes #508

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/57f5ba8b-7792-43d5-823d-303971bc178b)

After:
![image](https://github.com/user-attachments/assets/26b9e7aa-d212-4c52-859b-45833627ec34)
