### PR TITLE
Ether unit allow string number

### DIFF
--- a/.changeset/chilled-frogs-battle.md
+++ b/.changeset/chilled-frogs-battle.md
@@ -1,5 +1,0 @@
----
-"@blobscan/web": patch
----
-
-Updated `EtherUnitDisplay` to accept `bigint`, `number`, or `string` for `amount` prop

--- a/.changeset/chilled-frogs-battle.md
+++ b/.changeset/chilled-frogs-battle.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Updated `EtherUnitDisplay` to accept `bigint`, `number`, or `string` for `amount` prop

--- a/apps/web/src/components/Cards/MetricCard.tsx
+++ b/apps/web/src/components/Cards/MetricCard.tsx
@@ -66,10 +66,6 @@ function formatMetric(
       formattedValue = formatBytes(value);
       break;
     case "ethereum":
-      if (typeof value == "number") {
-        value = BigInt(Math.round(value));
-      }
-
       formattedValue = prettyFormatWei(value, "Gwei");
       break;
     case "percentage":

--- a/apps/web/src/components/Displays/EtherUnitDisplay.tsx
+++ b/apps/web/src/components/Displays/EtherUnitDisplay.tsx
@@ -4,7 +4,7 @@ import { formatWei, findBestUnit } from "@blobscan/eth-units";
 import type { EtherUnit } from "@blobscan/eth-units";
 
 type Props = {
-  amount: bigint;
+  amount: bigint | number | string;
   toUnit?: EtherUnit;
 };
 

--- a/apps/web/src/components/ExplorerDetails.tsx
+++ b/apps/web/src/components/ExplorerDetails.tsx
@@ -51,11 +51,7 @@ export function ExplorerDetails() {
       name: "Blob gas price",
       icon: <Gas className="h-4 w-4" />,
       value: latestBlock && (
-        <EtherUnitDisplay
-          amount={BigInt(
-            Math.round(Number(latestBlock.blobGasPrice.toString()))
-          )}
-        />
+        <EtherUnitDisplay amount={latestBlock.blobGasPrice.toString()} />
       ),
     },
   ];

--- a/packages/eth-format/index.ts
+++ b/packages/eth-format/index.ts
@@ -50,11 +50,7 @@ export function convertWei(
  * This function finds the best unit to display the value of `wei`.
  */
 export function findBestUnit(wei: bigint | string | number): EtherUnit {
-  if (typeof wei === "number") {
-    wei = Math.round(wei);
-  }
-
-  const length = wei.toString().length;
+  const length = countIntegerDigits(wei);
 
   if (length >= ETH_UNITS.ether) {
     return "ether";
@@ -65,6 +61,27 @@ export function findBestUnit(wei: bigint | string | number): EtherUnit {
   }
 
   return "wei";
+}
+
+/**
+ * Returns the number of integer digits in the value.
+ */
+export function countIntegerDigits(value: string | number | bigint): number {
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return 0; // Return 0 for Infinity, -Infinity, and NaN
+  }
+
+  value = value.toString();
+
+  const negative = value.startsWith("-");
+
+  if (negative) {
+    value = value.slice(1);
+  }
+
+  const [integer = ""] = value.split(".");
+
+  return integer.length;
 }
 
 /**

--- a/packages/eth-format/index.ts
+++ b/packages/eth-format/index.ts
@@ -49,7 +49,11 @@ export function convertWei(
 /**
  * This function finds the best unit to display the value of `wei`.
  */
-export function findBestUnit(wei: bigint): EtherUnit {
+export function findBestUnit(wei: bigint | string | number): EtherUnit {
+  if (typeof wei === "number") {
+    wei = Math.round(wei);
+  }
+
   const length = wei.toString().length;
 
   if (length >= ETH_UNITS.ether) {

--- a/packages/eth-format/index.ts
+++ b/packages/eth-format/index.ts
@@ -30,7 +30,10 @@ export function formatWei(
  * is preserved. Instead, this function provides a more human-readable
  * representation of the value.
  */
-export function prettyFormatWei(wei: bigint, toUnit: EtherUnit = "Gwei") {
+export function prettyFormatWei(
+  wei: string | number | bigint,
+  toUnit: EtherUnit = "Gwei"
+) {
   const converted = convertWei(wei, toUnit) as Intl.StringNumericLiteral;
   const formatted = compactFormatter.format(converted);
   return `${formatted} ${toUnit}`;

--- a/packages/eth-format/test/eth-units.test.ts
+++ b/packages/eth-format/test/eth-units.test.ts
@@ -1,6 +1,11 @@
-import { expect, test } from "vitest";
+import { expect, describe, test } from "vitest";
 
-import { convertWei, shiftDecimal, formatWei } from "../index";
+import {
+  convertWei,
+  shiftDecimal,
+  formatWei,
+  countIntegerDigits,
+} from "../index";
 
 test("converts wei", () => {
   expect(convertWei(BigInt("1"), "wei")).toBe("1");
@@ -358,4 +363,54 @@ test("can shift negative decimal string values", () => {
 
   expect(shiftDecimal("-123.123", 1)).toBe("-12.3123");
   expect(shiftDecimal("-123.123", 2)).toBe("-1.23123");
+});
+
+describe("countIntegerDigits", () => {
+  test("handles positive integers", () => {
+    expect(countIntegerDigits(123)).toBe(3);
+    expect(countIntegerDigits(1)).toBe(1);
+    expect(countIntegerDigits(1000)).toBe(4);
+  });
+
+  test("handles negative integers", () => {
+    expect(countIntegerDigits(-123)).toBe(3);
+    expect(countIntegerDigits(-1)).toBe(1);
+    expect(countIntegerDigits(-1000)).toBe(4);
+  });
+
+  test("handles zero", () => {
+    expect(countIntegerDigits(0)).toBe(1);
+  });
+
+  test("handles decimal numbers", () => {
+    expect(countIntegerDigits(123.45)).toBe(3);
+    expect(countIntegerDigits(-123.45)).toBe(3);
+    expect(countIntegerDigits(0.123)).toBe(1);
+    expect(countIntegerDigits(-0.123)).toBe(1);
+  });
+
+  test("handles string input", () => {
+    expect(countIntegerDigits("123")).toBe(3);
+    expect(countIntegerDigits("-123")).toBe(3);
+    expect(countIntegerDigits("123.45")).toBe(3);
+    expect(countIntegerDigits("-123.45")).toBe(3);
+  });
+
+  test("handles bigint input", () => {
+    expect(countIntegerDigits(BigInt("12345678901234567890"))).toBe(20);
+    expect(countIntegerDigits(BigInt("-12345678901234567890"))).toBe(20);
+  });
+
+  test("handles special number values", () => {
+    expect(countIntegerDigits(Infinity)).toBe(0);
+    expect(countIntegerDigits(-Infinity)).toBe(0);
+    expect(countIntegerDigits(NaN)).toBe(0);
+  });
+
+  test("handles edge cases", () => {
+    expect(countIntegerDigits("0.0")).toBe(1);
+    expect(countIntegerDigits("-0.0")).toBe(1);
+    expect(countIntegerDigits(".123")).toBe(0);
+    expect(countIntegerDigits("-.123")).toBe(0);
+  });
 });


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Updated `EtherUnitDisplay` to accept `bigint`, `number`, or `string` for `amount` prop

### Related Issue
Closes #521