### PR TITLE
feat: Update MetricCard to use findBestUnit for Ethereum values

### DIFF
--- a/apps/web/src/components/Cards/MetricCard.tsx
+++ b/apps/web/src/components/Cards/MetricCard.tsx
@@ -5,7 +5,7 @@ import cn from "classnames";
 import "react-loading-skeleton/dist/skeleton.css";
 import Skeleton from "react-loading-skeleton";
 
-import { prettyFormatWei } from "@blobscan/eth-units";
+import { findBestUnit, prettyFormatWei } from "@blobscan/eth-units";
 
 import { formatBytes, formatNumber } from "~/utils";
 import { Card } from "./Card";
@@ -66,7 +66,7 @@ function formatMetric(
       formattedValue = formatBytes(value);
       break;
     case "ethereum":
-      formattedValue = prettyFormatWei(value, "Gwei");
+      formattedValue = prettyFormatWei(value, findBestUnit(value));
       break;
     case "percentage":
       formattedValue = `${formatNumber(value, mode, {


### PR DESCRIPTION
### Description
Update MetricCard to use `findBestUnit` for Ethereum values

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/3958b436-dd47-4c08-9148-1821bf59b0d4)

After:
![image](https://github.com/user-attachments/assets/338fdabf-93e5-4b37-a0e9-0748c97011fc)

