### PR TITLE
refactor: move `Last Synced Slot` and `Swarm Data Expiry` to footer

### DIFF
--- a/.changeset/quiet-islands-greet.md
+++ b/.changeset/quiet-islands-greet.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Moved less important items from ExplorerDetails to footer

--- a/apps/web/src/components/AppLayout/BottomBarLayout/index.tsx
+++ b/apps/web/src/components/AppLayout/BottomBarLayout/index.tsx
@@ -5,7 +5,6 @@ import { ExplorerDetails } from "~/components/ExplorerDetails";
 import { IconButton } from "~/components/IconButton";
 import { Link } from "~/components/Link";
 import { env } from "~/env.mjs";
-import { useBreakpoint } from "~/hooks/useBreakpoint";
 import DiscordIcon from "~/icons/discord.svg";
 import GithubIcon from "~/icons/github.svg";
 import XIcon from "~/icons/x.svg";
@@ -26,15 +25,9 @@ const EXTERNAL_APPS: { href: string; icon: ReactElement }[] = [
 ];
 
 export const BottomBarLayout = () => {
-  const breakpoint = useBreakpoint();
-  const isSmallScreen = breakpoint === "default";
-
   return (
     <div className="flex flex-col items-center justify-center p-2">
       <div className="mt-4 flex flex-col items-center gap-2 sm:mt-8">
-        <div className="mb-2">
-          <ExplorerDetails placement="footer" isSmallScreen={isSmallScreen} />
-        </div>
         <div className="flex items-center gap-2">
           {EXTERNAL_APPS.map(({ icon, href }) => (
             <Link key={href} href={href} isExternal hideExternalIcon>
@@ -49,6 +42,9 @@ export const BottomBarLayout = () => {
           </Link>{" "}
           shard blob transactions, providing the necessary infrastructure to
           scale Ethereum.
+        </div>
+        <div className="my-1">
+          <ExplorerDetails placement="footer" />
         </div>
         {env.NEXT_PUBLIC_VERSION && (
           <div className="flex items-center gap-1">

--- a/apps/web/src/components/AppLayout/BottomBarLayout/index.tsx
+++ b/apps/web/src/components/AppLayout/BottomBarLayout/index.tsx
@@ -5,6 +5,7 @@ import { ExplorerDetails } from "~/components/ExplorerDetails";
 import { IconButton } from "~/components/IconButton";
 import { Link } from "~/components/Link";
 import { env } from "~/env.mjs";
+import { useBreakpoint } from "~/hooks/useBreakpoint";
 import DiscordIcon from "~/icons/discord.svg";
 import GithubIcon from "~/icons/github.svg";
 import XIcon from "~/icons/x.svg";
@@ -25,12 +26,15 @@ const EXTERNAL_APPS: { href: string; icon: ReactElement }[] = [
 ];
 
 export const BottomBarLayout = () => {
+  const breakpoint = useBreakpoint();
+  const isSmallScreen = breakpoint === "default";
+
   return (
-    <div className=" flex flex-col items-center justify-center p-2">
-      <div className="sm:hidden">
-        <ExplorerDetails />
-      </div>
+    <div className="flex flex-col items-center justify-center p-2">
       <div className="mt-4 flex flex-col items-center gap-2 sm:mt-8">
+        <div className="mb-2">
+          <ExplorerDetails placement="footer" isSmallScreen={isSmallScreen} />
+        </div>
         <div className="flex items-center gap-2">
           {EXTERNAL_APPS.map(({ icon, href }) => (
             <Link key={href} href={href} isExternal hideExternalIcon>

--- a/apps/web/src/components/AppLayout/TopBarLayout/TopBar.tsx
+++ b/apps/web/src/components/AppLayout/TopBarLayout/TopBar.tsx
@@ -32,7 +32,7 @@ export const TopBar: React.FC = () => {
       </TopBarSurface>
       <TopBarSurface>
         <div className="-my-1 flex items-center gap-2">
-          <ExplorerDetails />
+          <ExplorerDetails placement="top" />
         </div>
       </TopBarSurface>
     </div>

--- a/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
+++ b/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
@@ -15,7 +15,7 @@ export const TopBarLayout: React.FC = () => {
     return (
       <nav className="z-10 flex h-16 w-full items-center justify-end px-4 md:justify-between">
         <div className="hidden w-full md:flex">
-          <ExplorerDetails />
+          <ExplorerDetails placement="top" />
         </div>
         <div className="flex items-center gap-3">
           <div className=" xl:hidden">

--- a/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
+++ b/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
@@ -14,7 +14,7 @@ export const TopBarLayout: React.FC = () => {
   if (isHomepage) {
     return (
       <nav className="z-10 flex h-16 w-full items-center justify-end px-4 md:justify-between">
-        <div className="hidden w-full md:flex">
+        <div className="w-full md:flex">
           <ExplorerDetails placement="top" />
         </div>
         <div className="flex items-center gap-3">

--- a/apps/web/src/components/ExplorerDetails.tsx
+++ b/apps/web/src/components/ExplorerDetails.tsx
@@ -38,20 +38,16 @@ function ExplorerDetailsItem({
 
 type ExplorerDetailsProps = {
   placement: "top" | "footer";
-  isSmallScreen?: boolean;
 };
 
-export function ExplorerDetails({
-  placement,
-  isSmallScreen = false,
-}: ExplorerDetailsProps) {
+export function ExplorerDetails({ placement }: ExplorerDetailsProps) {
   const { data: syncStateData } = api.syncState.getState.useQuery();
   const { data: blobStoragesState } = api.blobStoragesState.getState.useQuery();
   const { data: latestBlock } = api.block.getLatestBlock.useQuery();
 
   const explorerDetailsItems: ExplorerDetailsItemProps[] = [];
 
-  if (placement === "top" || isSmallScreen) {
+  if (placement === "top") {
     explorerDetailsItems.push(
       { name: "Network", value: capitalize(env.NEXT_PUBLIC_NETWORK_NAME) },
       {
@@ -86,12 +82,14 @@ export function ExplorerDetails({
   }
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2 align-middle text-xs text-contentSecondary-light dark:text-contentSecondary-dark sm:h-4">
+    <div className="flex flex-col flex-wrap items-center justify-center gap-2 align-middle text-xs text-contentSecondary-light dark:text-contentSecondary-dark sm:h-4 sm:flex-row">
       {explorerDetailsItems.map(({ name, value, icon }, i) => {
         return (
           <div key={name} className="flex items-center gap-2">
             <ExplorerDetailsItem name={name} value={value} icon={icon} />
-            {i < explorerDetailsItems.length - 1 ? "･" : ""}
+            <span className="hidden sm:flex">
+              {i < explorerDetailsItems.length - 1 ? "･" : ""}
+            </span>
           </div>
         );
       })}

--- a/apps/web/src/components/ExplorerDetails.tsx
+++ b/apps/web/src/components/ExplorerDetails.tsx
@@ -36,29 +36,48 @@ function ExplorerDetailsItem({
   );
 }
 
-export function ExplorerDetails() {
+type ExplorerDetailsProps = {
+  placement: "top" | "footer";
+  isSmallScreen?: boolean;
+};
+
+export function ExplorerDetails({
+  placement,
+  isSmallScreen = false,
+}: ExplorerDetailsProps) {
   const { data: syncStateData } = api.syncState.getState.useQuery();
   const { data: blobStoragesState } = api.blobStoragesState.getState.useQuery();
   const { data: latestBlock } = api.block.getLatestBlock.useQuery();
 
-  const explorerDetailsItems: ExplorerDetailsItemProps[] = [
-    { name: "Network", value: capitalize(env.NEXT_PUBLIC_NETWORK_NAME) },
-    {
+  const explorerDetailsItems: ExplorerDetailsItemProps[] = [];
+
+  if (placement === "top" || isSmallScreen) {
+    explorerDetailsItems.push(
+      { name: "Network", value: capitalize(env.NEXT_PUBLIC_NETWORK_NAME) },
+      {
+        name: "Blob gas price",
+        icon: <Gas className="h-4 w-4" />,
+        value: latestBlock && (
+          <EtherUnitDisplay amount={latestBlock.blobGasPrice.toString()} />
+        ),
+      }
+    );
+  }
+
+  if (placement === "footer") {
+    explorerDetailsItems.push({
       name: "Last synced slot",
       value: syncStateData
         ? formatNumber(syncStateData.lastUpperSyncedSlot ?? 0)
         : undefined,
-    },
-    {
-      name: "Blob gas price",
-      icon: <Gas className="h-4 w-4" />,
-      value: latestBlock && (
-        <EtherUnitDisplay amount={latestBlock.blobGasPrice.toString()} />
-      ),
-    },
-  ];
+    });
+  }
 
-  if (blobStoragesState && blobStoragesState.swarmDataTTL) {
+  if (
+    placement === "footer" &&
+    blobStoragesState &&
+    blobStoragesState.swarmDataTTL
+  ) {
     explorerDetailsItems.push({
       name: "Swarm blob data expiry",
       value: formatTtl(blobStoragesState.swarmDataTTL),
@@ -67,7 +86,7 @@ export function ExplorerDetails() {
   }
 
   return (
-    <div className="sm:fle flex w-full flex-wrap items-center justify-center gap-2 align-middle text-xs text-contentSecondary-light dark:text-contentSecondary-dark sm:h-4 sm:justify-start">
+    <div className="flex flex-wrap items-center justify-center gap-2 align-middle text-xs text-contentSecondary-light dark:text-contentSecondary-dark sm:h-4">
       {explorerDetailsItems.map(({ name, value, icon }, i) => {
         return (
           <div key={name} className="flex items-center gap-2">


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
`Last Synced Slot` and `Swarm Data Expiry` items from the `ExplorerDetails` have been moved to the footer

### Related Issue 

Closes #517 

### Screenshots 
| Top  | Bottom   |  
|---|---|
| <img width="366" alt="image" src="https://github.com/user-attachments/assets/7785a50e-001a-449a-9a26-7ef7dabf5aa8">  | <img width="651" alt="image" src="https://github.com/user-attachments/assets/93855e77-5177-4ccb-a59c-a0233c44130f">  |  
| <img width="437" alt="image" src="https://github.com/user-attachments/assets/8e59d276-c48f-452b-b1b3-b0ef93b0e348"> |  <img width="445" alt="image" src="https://github.com/user-attachments/assets/f3752815-f050-427d-9211-a1deaa0b5045"> |  

