### PR TITLE
fix(web): explorer details not aligned in small screens

### DIFF
--- a/.changeset/yellow-hats-march.md
+++ b/.changeset/yellow-hats-march.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed explorer details not horizontally aligned in small screens in the top

--- a/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
+++ b/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
@@ -14,11 +14,11 @@ export const TopBarLayout: React.FC = () => {
   if (isHomepage) {
     return (
       <nav className="z-10 flex h-16 w-full items-center justify-end px-4 md:justify-between">
-        <div className="w-full md:flex">
+        <div className="ml-5 w-full md:ml-0 md:flex">
           <ExplorerDetails placement="top" />
         </div>
         <div className="flex items-center gap-3">
-          <div className=" xl:hidden">
+          <div className="xl:hidden">
             <SidebarNavigationMenu />
           </div>
           <div className="hidden xl:flex">


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
The `ExplorerDetails` component has been aligned horizontally when the screen size is small and is placed in the top

### Related Issue 
Closes #556 

### Screenshots 

<img width="402" alt="image" src="https://github.com/user-attachments/assets/99d805a1-714e-4c46-aacb-3afc781c530f">
