### PR TITLE
perf(db): add rollup indexes

### DIFF
--- a/packages/db/prisma/migrations/20240909234614_remove_redundant_block_number_index/migration.sql
+++ b/packages/db/prisma/migrations/20240909234614_remove_redundant_block_number_index/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "transaction_block_number_idx";

--- a/packages/db/prisma/migrations/20240909234808_add_rollup_index/migration.sql
+++ b/packages/db/prisma/migrations/20240909234808_add_rollup_index/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "transaction_category_idx";
+
+-- CreateIndex
+CREATE INDEX "transaction_category_rollup_block_number_index_idx" ON "transaction"("category", "rollup", "block_number", "index");

--- a/packages/db/prisma/migrations/20240910000321_add_tx_sender_receiver_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20240910000321_add_tx_sender_receiver_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "transaction_block_timestamp_idx";
+
+-- CreateIndex
+CREATE INDEX "transaction_block_timestamp_category_rollup_block_number_in_idx" ON "transaction"("block_timestamp", "category", "rollup", "block_number", "index");
+
+-- CreateIndex
+CREATE INDEX "transaction_from_id_block_number_index_idx" ON "transaction"("from_id", "block_number", "index");
+
+-- CreateIndex
+CREATE INDEX "transaction_to_id_block_number_index_idx" ON "transaction"("to_id", "block_number", "index");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -169,8 +169,10 @@ model Transaction {
   @@index([insertedAt])
   @@index([blockHash])
   @@index([blockNumber, index])
-  @@index([blockTimestamp])
+  @@index([blockTimestamp, category, rollup, blockNumber, index])
   @@index([category, rollup, blockNumber, index])
+  @@index([fromId, blockNumber, index])
+  @@index([toId, blockNumber, index])
   @@map("transaction")
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -168,7 +168,6 @@ model Transaction {
 
   @@index([insertedAt])
   @@index([blockHash])
-  @@index([blockNumber])
   @@index([blockNumber, index])
   @@index([blockTimestamp])
   @@index([category])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -170,7 +170,7 @@ model Transaction {
   @@index([blockHash])
   @@index([blockNumber, index])
   @@index([blockTimestamp])
-  @@index([category])
+  @@index([category, rollup, blockNumber, index])
   @@map("transaction")
 }
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Resolves #547 
 
This PR introduces the following indexes to the `Transaction` model:

- `(category, rollup, block_number, index)`: This index allows efficient filtering by category and rollup, while ensuring the results are sorted by `block_number` and `index` without needing an additional sorting step.
- `(fromId, block_number, index)`: Similar to the above, this index enables filtering by the transaction sender (`fromId`), while also returning results sorted by `block_number` and `index`.
- `(toId, block_number, index)`: Like the previous index, but this one allows filtering by the transaction receiver (`toId`), with results also sorted by `block_number` and `index`.

#### Motivation and Context (Optional)
Some filtering queries on the client have been experiencing timeouts, particularly when filtering blobs by rollup. This occurs because PostgreSQL needs to perform a full table scan to locate rows that match the selected rollup values.

### Related Issue (Optional)

### Screenshots (if appropriate):
