### PR TITLE
feat: Improvements in stats page

### DIFF
--- a/apps/web/src/components/Charts/Blob/DailyBlobSizeChart.tsx
+++ b/apps/web/src/components/Charts/Blob/DailyBlobSizeChart.tsx
@@ -27,6 +27,9 @@ export const DailyBlobSizeChart: FC<Partial<DailyBlobsSizeProps>> = function ({
       },
       yUnit: "bytes",
     }),
+    grid: {
+      containLabel: true,
+    },
     series: [
       {
         name: "Blob Size",

--- a/apps/web/src/components/Charts/Blob/DailyBlobsChart.tsx
+++ b/apps/web/src/components/Charts/Blob/DailyBlobsChart.tsx
@@ -20,10 +20,12 @@ export const DailyBlobsChart: FC<Partial<DailyBlobsChartProps>> = function ({
     ...buildTimeSeriesOptions({
       dates: days,
       axisFormatters: {
-        yAxisTooltip: formatNumber,
+        yAxisTooltip: (value) => formatNumber(value, "compact"),
       },
     }),
-
+    grid: {
+      containLabel: true,
+    },
     series: [
       {
         name: "Total Blobs",

--- a/apps/web/src/components/Charts/Block/DailyAvgBlobFeeChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyAvgBlobFeeChart.tsx
@@ -16,12 +16,12 @@ export const DailyAvgBlobFeeChart: FC<Partial<DailyAvgBlobFeeChartProps>> =
   function ({ days, avgBlobFees }) {
     const { scaledValues, unit } = useScaledWeiAmounts(avgBlobFees);
 
-    const options: EChartOption<EChartOption.SeriesBar> = {
+    const options: EChartOption<EChartOption.Series> = {
       ...buildTimeSeriesOptions({
         dates: days,
         axisFormatters: {
-          yAxisTooltip: (value) => `${formatNumber(value)} ${unit}`,
-          yAxisLabel: (value) => `${formatNumber(value)} ${unit}`,
+          yAxisTooltip: (value) => `${formatNumber(value, "compact")} ${unit}`,
+          yAxisLabel: (value) => `${formatNumber(value, "compact")} ${unit}`,
         },
         yUnit: "ethereum",
       }),
@@ -32,7 +32,7 @@ export const DailyAvgBlobFeeChart: FC<Partial<DailyAvgBlobFeeChartProps>> =
         {
           name: "Avg. Blob Fees",
           data: scaledValues,
-          type: "bar",
+          type: "line",
         },
       ],
       animationEasing: "cubicOut",

--- a/apps/web/src/components/Charts/Block/DailyAvgBlobGasPriceChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyAvgBlobGasPriceChart.tsx
@@ -16,12 +16,12 @@ export const DailyAvgBlobGasPriceChart: FC<
 > = function ({ days, avgBlobGasPrices }) {
   const { scaledValues, unit } = useScaledWeiAmounts(avgBlobGasPrices);
 
-  const options: EChartOption<EChartOption.SeriesBar> = {
+  const options: EChartOption<EChartOption.Series> = {
     ...buildTimeSeriesOptions({
       dates: days,
       axisFormatters: {
-        yAxisTooltip: (value) => `${formatNumber(value)} ${unit}`,
-        yAxisLabel: (value) => `${formatNumber(value)} ${unit}`,
+        yAxisTooltip: (value) => `${formatNumber(value, "compact")} ${unit}`,
+        yAxisLabel: (value) => `${formatNumber(value, "compact")} ${unit}`,
       },
       yUnit: "ethereum",
     }),
@@ -32,7 +32,7 @@ export const DailyAvgBlobGasPriceChart: FC<
       {
         name: "Avg. Blob Gas Prices",
         data: scaledValues,
-        type: "bar",
+        type: "line",
       },
     ],
     animationEasing: "cubicOut",

--- a/apps/web/src/components/Charts/Block/DailyBlobFeeChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyBlobFeeChart.tsx
@@ -22,8 +22,8 @@ export const DailyBlobFeeChart: FC<Partial<DailyBlobFeeChartProps>> =
       ...buildTimeSeriesOptions({
         dates: days,
         axisFormatters: {
-          yAxisTooltip: (value) => `${formatNumber(value)} ${unit}`,
-          yAxisLabel: (value) => `${formatNumber(value)} ${unit}`,
+          yAxisTooltip: (value) => `${formatNumber(value, "compact")} ${unit}`,
+          yAxisLabel: (value) => `${formatNumber(value, "compact")} ${unit}`,
         },
         yUnit: "ethereum",
       }),

--- a/apps/web/src/components/Charts/Block/DailyBlobGasComparisonChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyBlobGasComparisonChart.tsx
@@ -4,6 +4,7 @@ import type { EChartOption } from "echarts";
 import { useTheme } from "next-themes";
 
 import { ChartCard } from "~/components/Cards/ChartCard";
+import { useScaledWeiAmounts } from "~/hooks/useScaledWeiAmounts";
 import type { DailyBlockStats } from "~/types";
 import { buildTimeSeriesOptions, formatNumber } from "~/utils";
 
@@ -17,17 +18,25 @@ export type DailyBlobGasComparisonChartProps = Partial<{
 export const DailyBlobGasComparisonChart: FC<DailyBlobGasComparisonChartProps> =
   function ({ blobAsCalldataGasUsed, blobGasUsed, days, opts = {} }) {
     const { resolvedTheme } = useTheme();
+    const { scaledValues, unit } = useScaledWeiAmounts(
+      blobGasUsed ? blobGasUsed.map((x) => Number(x)) : []
+    );
+
     const options: EChartOption<EChartOption.Series> = {
       ...buildTimeSeriesOptions({
         dates: days,
         axisFormatters: {
-          yAxisTooltip: (value) => formatNumber(value, "compact"),
+          yAxisTooltip: (value) => `${formatNumber(value, "compact")} ${unit}`,
+          yAxisLabel: (value) => `${formatNumber(value, "compact")} ${unit}`,
         },
       }),
+      grid: {
+        containLabel: true,
+      },
       series: [
         {
           name: "Blob Gas Used",
-          data: blobGasUsed,
+          data: scaledValues,
           stack: "gas",
           type: "bar",
 

--- a/apps/web/src/components/Charts/Block/DailyBlobGasUsedChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyBlobGasUsedChart.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import type { EChartOption } from "echarts";
 
 import { ChartCard } from "~/components/Cards/ChartCard";
+import { useScaledWeiAmounts } from "~/hooks/useScaledWeiAmounts";
 import type { DailyBlockStats } from "~/types";
 import { buildTimeSeriesOptions, formatNumber } from "~/utils";
 
@@ -12,17 +13,24 @@ export type DailyBlobGasUsedChartProps = Partial<{
 
 const BaseChart: FC<DailyBlobGasUsedChartProps & { title: string }> =
   function ({ days, blobGasUsed, title }) {
+    const { scaledValues, unit } = useScaledWeiAmounts(
+      blobGasUsed ? blobGasUsed.map((x) => Number(x)) : []
+    );
     const options: EChartOption<EChartOption.SeriesBar> = {
       ...buildTimeSeriesOptions({
         dates: days,
         axisFormatters: {
-          yAxisTooltip: (value) => formatNumber(value),
+          yAxisTooltip: (value) => `${formatNumber(value, "compact")} ${unit}`,
+          yAxisLabel: (value) => `${formatNumber(value, "compact")} ${unit}`,
         },
       }),
+      grid: {
+        containLabel: true,
+      },
       series: [
         {
           name: "Blob Gas Used",
-          data: blobGasUsed,
+          data: scaledValues,
           stack: "gas",
           type: "bar",
         },

--- a/apps/web/src/components/Charts/Block/DailyBlocksChart.tsx
+++ b/apps/web/src/components/Charts/Block/DailyBlocksChart.tsx
@@ -18,9 +18,12 @@ export const DailyBlocksChart: FC<Partial<DailyBlocksChartProps>> = function ({
     ...buildTimeSeriesOptions({
       dates: days,
       axisFormatters: {
-        yAxisTooltip: (value) => formatNumber(value),
+        yAxisTooltip: (value) => formatNumber(value, "compact"),
       },
     }),
+    grid: {
+      containLabel: true,
+    },
     series: [
       {
         name: "Total Blocks",


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
1. Display 3.5M wei instead of 3,500,000 wei
2. Display `Daily Avg. Blob Fee` and `Daily Avg. Blob Gas Price` as line charts by default.
3. Use the best unit in `Daily Blob Gas Expenditure Comparison`.

### Related Issue
Closes [#540](https://github.com/Blobscan/blobscan/issues/540)

### Screenshots:
Before:
![image](https://github.com/user-attachments/assets/38d50b40-c3c9-4390-ae82-d5f3b2d79dae)

After:
![image](https://github.com/user-attachments/assets/f7ba694c-ed73-450b-89ed-75a53f2d500d)

Before:
![image](https://github.com/user-attachments/assets/56f73964-7142-4143-9dc3-6035c64f6228)

After:

![image](https://github.com/user-attachments/assets/8780478e-073e-431c-a98a-1ad944518001)

Before:
![image](https://github.com/user-attachments/assets/5bf5f2fc-aba9-4fc5-9dd6-704c3dce03cc)

After:
![image](https://github.com/user-attachments/assets/56047a84-1fd9-437c-be5c-ad1317975126)
