### PR TITLE
fix: Top `ExplorerDetails` not horizontally center aligned in small screens

### DIFF
--- a/.changeset/dirty-seals-appear.md
+++ b/.changeset/dirty-seals-appear.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed top explorer details not horizontally aligned in small screens.

--- a/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
+++ b/apps/web/src/components/AppLayout/TopBarLayout/index.tsx
@@ -14,11 +14,11 @@ export const TopBarLayout: React.FC = () => {
   if (isHomepage) {
     return (
       <nav className="z-10 flex h-16 w-full items-center justify-end px-4 md:justify-between">
-        <div className="w-full md:flex">
+        <div className="ml-5 w-full md:ml-0 md:flex">
           <ExplorerDetails placement="top" />
         </div>
         <div className="flex items-center gap-3">
-          <div className=" xl:hidden">
+          <div className="xl:hidden">
             <SidebarNavigationMenu />
           </div>
           <div className="hidden xl:flex">


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
The right hamburger menu affected the center placement of the Explorer Details. Adding some space on the left side of the details equal to the width of the menu icon should fix the problem.


### Related Issue (Optional)
Closes #556 
Fixes #517 

### Screenshots 
![image](https://github.com/user-attachments/assets/6534d240-071d-4147-952f-f39b194d398d)

