### PR TITLE
fix(web): Copyable values overflow viewport on small screens

### DIFF
--- a/.changeset/rotten-llamas-pull.md
+++ b/.changeset/rotten-llamas-pull.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed copyable values overflow viewport on small screens

--- a/apps/web/src/components/CopyToClipboard.tsx
+++ b/apps/web/src/components/CopyToClipboard.tsx
@@ -48,7 +48,7 @@ export function CopyToClipboard({
 export function Copyable({ label, value }: CopyToClipboardProps) {
   return (
     <div className="flex items-center gap-2">
-      {value}
+      <div className="truncate">{value}</div>
       <CopyToClipboard value={value} label={label} />
     </div>
   );

--- a/apps/web/src/components/InfoGrid.tsx
+++ b/apps/web/src/components/InfoGrid.tsx
@@ -19,22 +19,26 @@ export const InfoGrid: React.FC<InfoGridProps> = function ({ fields }) {
   const skeletonHeight = isCompact ? 15 : 15;
 
   return (
-    <div className="grid w-full gap-3 md:grid-cols-4">
+    <div className="grid w-full grid-cols-4 gap-3">
       {!fields
         ? Array.from({ length: skeletonsLength }).map((_, i) => (
             <Fragment key={i}>
-              <div>
+              <div className="col-span-4 md:col-span-1">
                 <Skeleton width={headerWidth} height={skeletonHeight} />
               </div>
-              <div className="col-span-3">
+              <div className="col-span-4 md:col-span-3">
                 <Skeleton width={valueWidth} height={skeletonHeight} />
               </div>
             </Fragment>
           ))
         : fields.map(({ name, value }, i) => (
             <Fragment key={i}>
-              <div className="font-semibold dark:text-coolGray-400">{name}</div>
-              <div className="col-span-3 break-words text-sm">{value}</div>
+              <div className="col-span-4 font-semibold dark:text-coolGray-400 md:col-span-1">
+                {name}
+              </div>
+              <div className="col-span-4 break-words text-sm md:col-span-3">
+                {value}
+              </div>
             </Fragment>
           ))}
     </div>


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Copyable values overflow viewport on small screens

### Related Issue
Closes [#548](https://github.com/Blobscan/blobscan/issues/548)

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/d3a43f6f-e60d-4a81-a64d-99afb6584a0d)

After:
![image](https://github.com/user-attachments/assets/86a2c870-9da1-4cec-be73-dce62b5fab08)
