### PR TITLE
Fix show more

### DIFF
--- a/.changeset/happy-hounds-join.md
+++ b/.changeset/happy-hounds-join.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed the issue where the "Show more" message was displayed incorrectly when the blob data container was opened and closed. The message now properly toggles between "Show more" when the container is closed and "Show less" when the container is open.

--- a/apps/web/src/components/ExpandableContent.tsx
+++ b/apps/web/src/components/ExpandableContent.tsx
@@ -46,11 +46,14 @@ export const ExpandableContent: FC<ExpandableElementProps> = function ({
               className="flex cursor-pointer items-center gap-1 text-primary-400 transition-colors hover:text-primary-300 "
               onClick={() => setOpened((opened) => !opened)}
             >
-              Show More{" "}
               {opened ? (
-                <ChevronUpIcon className="h-5 w-5" />
+                <>
+                  Show More <ChevronUpIcon className="h-5 w-5" />
+                </>
               ) : (
-                <ChevronDownIcon className="h-5 w-5" />
+                <>
+                  Show Less <ChevronDownIcon className="h-5 w-5" />
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fixed the issue where the "Show more" message was displayed incorrectly when the blob data container was opened and closed. The message now properly toggles between "Show more" when the container is closed and "Show less" when the container is open.

### Related Issue
Closes #565

### Screenshots:
Before:
![image](https://github.com/user-attachments/assets/a1c11521-ca95-4325-91d5-de332b1c5f33)
![image](https://github.com/user-attachments/assets/de042261-2eec-405e-8d03-df0077637153)

