### PR TITLE
refactor: Simplify SurfaceCardBase component

### DIFF
--- a/apps/web/src/components/Cards/SurfaceCards/SurfaceCardBase.tsx
+++ b/apps/web/src/components/Cards/SurfaceCards/SurfaceCardBase.tsx
@@ -1,30 +1,23 @@
-import type { FC, ReactNode } from "react";
+import type { FC } from "react";
+import { twMerge } from "tailwind-merge";
 
-type SurfaceCardBaseProps = {
-  children: ReactNode;
-  className?: string;
-  truncateText?: boolean;
-};
-
-export const SurfaceCardBase: FC<SurfaceCardBaseProps> = function ({
-  children,
+export const SurfaceCardBase: FC<React.HTMLAttributes<HTMLDivElement>> = ({
   className,
-  truncateText = true,
-}) {
-  return (
-    <div
-      className={`
+  ...props
+}) => (
+  <div
+    className={twMerge(
+      `
     dark:bg-neutral-850
-    ${truncateText ? "truncate" : ""}
+    truncate
     rounded-md
     border
     border-border-light
     p-4
     dark:border-border-dark
-    ${className}
-    `}
-    >
-      {children}
-    </div>
-  );
-};
+    `,
+      className
+    )}
+    {...props}
+  />
+);


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This update refactors the `SurfaceCardBase` component to improve its flexibility and simplify style overrides:

1. Integration of `twMerge`: The `SurfaceCardBase` component now leverages `twMerge` to allow easy style overrides. By using `twMerge`, custom styles passed via `className` will correctly override default styles.
2. Removal of `truncateText`: The `truncateText` prop has been removed, as it is not used anywhere in the codebase. With the introduction of `twMerge`, text truncation and other styles can now be customized or overridden by passing a `className`.

This change maintains the same component behavior while enhancing the ability to customize styles.
