### PR TITLE
fix(web): add a "reorg" label to reorged slots/blocks search results

### DIFF
--- a/.changeset/strong-masks-remain.md
+++ b/.changeset/strong-masks-remain.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+A new label "reorg" has been added to the reorged slots/blocks search results

--- a/.changeset/strong-masks-remain.md
+++ b/.changeset/strong-masks-remain.md
@@ -2,4 +2,4 @@
 "@blobscan/web": patch
 ---
 
-A new label "reorg" has been added to the reorged slots/blocks search results
+Added a new label "reorg" to the reorged slots/blocks search results

--- a/apps/web/src/components/Badges/Badge.tsx
+++ b/apps/web/src/components/Badges/Badge.tsx
@@ -16,6 +16,15 @@ const badgeVariants = cva(
   `,
   {
     variants: {
+      variant: {
+        none: "",
+        primary: `
+          bg-accent-light
+          text-accentContent-light
+          dark:bg-primary-500
+          dark:text-accentContent-dark"
+        `,
+      },
       size: {
         xs: "text-xs",
         sm: "text-sm",
@@ -24,6 +33,7 @@ const badgeVariants = cva(
       },
     },
     defaultVariants: {
+      variant: "none",
       size: "md",
     },
   }
@@ -35,11 +45,15 @@ export type BadgeProps = React.HTMLAttributes<HTMLDivElement> &
 export const Badge: React.FC<BadgeProps> = ({
   className,
   size,
+  variant,
   children,
   ...props
 }) => {
   return (
-    <div className={twMerge(badgeVariants({ size }), className)} {...props}>
+    <div
+      className={twMerge(badgeVariants({ size, variant }), className)}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/apps/web/src/components/Badges/Badge.tsx
+++ b/apps/web/src/components/Badges/Badge.tsx
@@ -17,7 +17,6 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        none: "",
         primary: `
           bg-accent-light
           text-accentContent-light
@@ -33,7 +32,6 @@ const badgeVariants = cva(
       },
     },
     defaultVariants: {
-      variant: "none",
       size: "md",
     },
   }

--- a/apps/web/src/components/Badges/StatusBadge.tsx
+++ b/apps/web/src/components/Badges/StatusBadge.tsx
@@ -49,7 +49,8 @@ const statusBadgeVariants = cva(
   }
 );
 
-type StatusBadgeProps = BadgeProps & VariantProps<typeof statusBadgeVariants>;
+type StatusBadgeProps = VariantProps<typeof statusBadgeVariants> &
+  Omit<BadgeProps, "variant">;
 
 export const StatusBadge: FC<StatusBadgeProps> = ({
   className,

--- a/apps/web/src/components/SearchInput/SearchResults.tsx
+++ b/apps/web/src/components/SearchInput/SearchResults.tsx
@@ -4,6 +4,7 @@ import { CpuChipIcon, CubeIcon, DocumentIcon } from "@heroicons/react/24/solid";
 
 import type { RouterOutputs } from "~/api-client";
 import { capitalize } from "~/utils";
+import { Badge } from "../Badges/Badge";
 import { Card } from "../Cards/Card";
 
 type SearchOutput = RouterOutputs["search"]["byTerm"];
@@ -46,11 +47,12 @@ function getCategoryInfo(type: SearchCategory): CategoryInfo | undefined {
 }
 
 const SearchResultItem: React.FC<SearchResultItemProps> = function ({
-  result: { id },
+  result: { id, label, reorg },
   category,
   onClick,
 }) {
-  const { icon, label } = getCategoryInfo(category) || {};
+  const { icon, label: categoryLabel } = getCategoryInfo(category) || {};
+
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
     <div className="flex flex-col" onClick={() => onClick(category, id)}>
@@ -58,13 +60,18 @@ const SearchResultItem: React.FC<SearchResultItemProps> = function ({
         <div className="flex w-11/12 items-center gap-2">
           {icon}
           <span className="flex truncate">
-            {label && (
+            {categoryLabel && (
               <div className="mr-1 text-content-light dark:text-content-dark">
-                {label}
+                {categoryLabel}
               </div>
             )}
-            {id}
+            {label}
           </span>
+          {reorg && (
+            <Badge variant="primary" className="text-xs">
+              reorg
+            </Badge>
+          )}
         </div>
         <ChevronRightIcon className="inline-block h-4 w-4 text-icon-light dark:text-icon-dark" />
       </div>

--- a/apps/web/src/components/SearchInput/SearchResults.tsx
+++ b/apps/web/src/components/SearchInput/SearchResults.tsx
@@ -69,7 +69,7 @@ const SearchResultItem: React.FC<SearchResultItemProps> = function ({
           </span>
           {reorg && (
             <Badge variant="primary" className="text-xs">
-              reorg
+              Reorg
             </Badge>
           )}
         </div>

--- a/packages/api/test/search.test.ts
+++ b/packages/api/test/search.test.ts
@@ -81,7 +81,9 @@ describe("Search route", async () => {
       expect(result).toMatchObject({
         block: [
           {
-            id: "1001",
+            label: "1001",
+            id: "blockHash001",
+            reorg: false,
           },
         ],
       });
@@ -96,7 +98,9 @@ describe("Search route", async () => {
       expect(result).toMatchObject({
         slot: [
           {
-            id: "1001",
+            id: "blockHash001",
+            label: "1001",
+            reorg: false,
           },
         ],
       });


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Adds a `reorg` label to reorged slots/blocks search results

### Related Issue
Closes #406

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/44bb9f87-d6f6-464b-8bc8-2c71d5a161b9)

After:
![image](https://github.com/user-attachments/assets/bb3687d8-e735-42e6-8a8e-91c8cf6d68e4)
![image](https://github.com/user-attachments/assets/446cc88b-8bc2-44e8-9c7d-968bfaa82e59)

