### PR TITLE
perf(db): update indexes

### DIFF
--- a/packages/api/src/routers/blob/getAll.ts
+++ b/packages/api/src/routers/blob/getAll.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@blobscan/db";
 import { z } from "@blobscan/zod";
 
 import {
@@ -44,6 +45,16 @@ export const getAll = publicProcedure
   .use(withExpands)
   .output(outputSchema)
   .query(async ({ ctx: { filters, expands, pagination, prisma, count } }) => {
+    let leadingOrderColumn: Prisma.BlobsOnTransactionsOrderByWithRelationInput =
+      {
+        blockTimestamp: filters.sort,
+      };
+
+    if (filters.blockNumber) {
+      leadingOrderColumn = {
+        blockNumber: filters.sort,
+      };
+    }
     const blockFiltersExists = filters.blockSlot || filters.blockType;
     const txFiltersExists =
       filters.transactionRollup !== undefined ||
@@ -70,7 +81,7 @@ export const getAll = publicProcedure
           : undefined,
       },
       orderBy: [
-        { blockTimestamp: filters.sort },
+        leadingOrderColumn,
         { txIndex: filters.sort },
         {
           index: filters.sort,

--- a/packages/db/prisma/migrations/20240928161343_swap_transaction_fork_composite_index_columns/migration.sql
+++ b/packages/db/prisma/migrations/20240928161343_swap_transaction_fork_composite_index_columns/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The primary key for the `transaction_fork` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "transaction_fork" DROP CONSTRAINT "transaction_fork_pkey",
+ADD CONSTRAINT "transaction_fork_pkey" PRIMARY KEY ("block_hash", "hash");

--- a/packages/db/prisma/migrations/20240929151029_update_tx_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20240929151029_update_tx_indexes/migration.sql
@@ -1,0 +1,20 @@
+-- DropIndex
+DROP INDEX "transaction_block_timestamp_category_rollup_block_number_in_idx";
+
+-- DropIndex
+DROP INDEX "transaction_from_id_block_number_index_idx";
+
+-- DropIndex
+DROP INDEX "transaction_to_id_block_number_index_idx";
+
+-- CreateIndex
+CREATE INDEX "transaction_block_timestamp_index_idx" ON "transaction"("block_timestamp", "index");
+
+-- CreateIndex
+CREATE INDEX "transaction_category_rollup_block_timestamp_index_idx" ON "transaction"("category", "rollup", "block_timestamp", "index");
+
+-- CreateIndex
+CREATE INDEX "transaction_from_id_block_timestamp_index_idx" ON "transaction"("from_id", "block_timestamp", "index");
+
+-- CreateIndex
+CREATE INDEX "transaction_to_id_block_timestamp_index_idx" ON "transaction"("to_id", "block_timestamp", "index");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -208,7 +208,7 @@ model TransactionFork {
   block       Block       @relation(fields: [blockHash], references: [hash])
   transaction Transaction @relation(fields: [hash], references: [hash])
 
-  @@id([hash, blockHash])
+  @@id([blockHash, hash])
   @@map("transaction_fork")
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -161,19 +161,21 @@ model Transaction {
   insertedAt            DateTime @default(now()) @map("inserted_at")
   updatedAt             DateTime @default(now()) @map("updated_at")
 
-  blobs            BlobsOnTransactions[]
-  block            Block                 @relation(fields: [blockHash], references: [hash])
-  from             Address               @relation("senderAddressRelation", fields: [fromId], references: [address])
-  to               Address               @relation("receiverAddressRelation", fields: [toId], references: [address])
+  blobs BlobsOnTransactions[]
+  block Block                 @relation(fields: [blockHash], references: [hash])
+  from  Address               @relation("senderAddressRelation", fields: [fromId], references: [address])
+  to    Address               @relation("receiverAddressRelation", fields: [toId], references: [address])
+
   transactionForks TransactionFork[]
 
-  @@index([insertedAt])
   @@index([blockHash])
+  @@index([blockTimestamp, index])
   @@index([blockNumber, index])
-  @@index([blockTimestamp, category, rollup, blockNumber, index])
+  @@index([category, rollup, blockTimestamp, index])
   @@index([category, rollup, blockNumber, index])
-  @@index([fromId, blockNumber, index])
-  @@index([toId, blockNumber, index])
+  @@index([fromId, blockTimestamp, index])
+  @@index([toId, blockTimestamp, index])
+  @@index([insertedAt])
   @@map("transaction")
 }
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description

#### Motivation and Context (Optional)
It applies the following changes:

- Swap the composite key of the `TransactionFork` model from (`hash`,`blockHash`) to (`blockHash`,`hash`) so that an index on `blockHash` is created.
- Replace `blockNumber` with `blockTimestamp` in the indexes of the `Transaction` model to leverage this for date filtering and normal sorting.
- Use `blockNumber` as sort column only when that filter has been provided in txs and blobs pages

### Related Issue (Optional)

### Screenshots (if appropriate):
