### PR TITLE
perf(api): optimise count retrieval

### DIFF
--- a/.changeset/nine-trees-eat.md
+++ b/.changeset/nine-trees-eat.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Optimized element count performance by retrieving pre-calculated values from the stats table when filtering by rollup, date, or with no filters applied

--- a/packages/api/src/middlewares/withFilters.ts
+++ b/packages/api/src/middlewares/withFilters.ts
@@ -1,7 +1,5 @@
 import type { Prisma } from "@blobscan/db";
 import type { Category, Rollup } from "@blobscan/db/prisma/enums";
-import { env } from "@blobscan/env";
-import { getRollupByAddress } from "@blobscan/rollups";
 import { z } from "@blobscan/zod";
 
 import { t } from "../trpc-client";
@@ -87,20 +85,6 @@ export function hasCustomFilters(filters: Filters) {
     sort !== "desc" ||
     blockType?.some !== undefined
   );
-}
-
-export function getRollupFromAddressFilter(
-  addressesFilter: Filters["transactionAddresses"]
-) {
-  if (!addressesFilter) {
-    return;
-  }
-
-  const fromAddress = addressesFilter.find(({ fromId }) => !!fromId)?.fromId;
-
-  if (!fromAddress || typeof fromAddress !== "string") return;
-
-  return getRollupByAddress(fromAddress, env.CHAIN_ID);
 }
 
 export const withFilters = t.middleware(({ next, input = {} }) => {

--- a/packages/api/src/utils/count.ts
+++ b/packages/api/src/utils/count.ts
@@ -1,0 +1,50 @@
+import { toDailyDatePeriod } from "@blobscan/dayjs";
+
+import { getRollupFromAddressFilter } from "../middlewares/withFilters";
+import type { Filters } from "../middlewares/withFilters";
+
+export function hasToPerformCount({
+  blockNumber,
+  blockSlot,
+  transactionAddresses,
+  blockType,
+}: Filters) {
+  const addressFiltersCount = transactionAddresses?.length ?? 0;
+  const hasRollupAsAddress = !!getRollupFromAddressFilter(transactionAddresses);
+  const reorgedFilterEnabled = !!blockType?.some;
+
+  return (
+    blockNumber ||
+    blockSlot ||
+    reorgedFilterEnabled ||
+    addressFiltersCount > 1 ||
+    (addressFiltersCount === 1 && !hasRollupAsAddress)
+  );
+}
+
+export function buildCountStatsFilters({
+  blockTimestamp,
+  transactionCategory,
+  transactionRollup,
+  transactionAddresses,
+}: Filters) {
+  // We set 'category' or 'rollup' to null when there are no corresponding filters
+  // because the db stores total statistics for each grouping in rows where
+  // 'category' or 'rollup' is null.
+  const rollup =
+    transactionRollup ??
+    getRollupFromAddressFilter(transactionAddresses) ??
+    null;
+  const category = (rollup ? null : transactionCategory) ?? null;
+  const { from: fromDay, to: toDay } = toDailyDatePeriod({
+    from: blockTimestamp?.gte,
+    to: blockTimestamp?.lt,
+  });
+
+  return {
+    category,
+    rollup,
+    fromDay,
+    toDay,
+  };
+}

--- a/packages/api/src/utils/count.ts
+++ b/packages/api/src/utils/count.ts
@@ -1,7 +1,22 @@
 import { toDailyDatePeriod } from "@blobscan/dayjs";
+import { env } from "@blobscan/env";
+import { getRollupByAddress } from "@blobscan/rollups";
 
-import { getRollupFromAddressFilter } from "../middlewares/withFilters";
 import type { Filters } from "../middlewares/withFilters";
+
+function getRollupFromAddressFilter(
+  addressesFilter: Filters["transactionAddresses"]
+) {
+  if (!addressesFilter) {
+    return;
+  }
+
+  const fromAddress = addressesFilter.find(({ fromId }) => !!fromId)?.fromId;
+
+  if (!fromAddress || typeof fromAddress !== "string") return;
+
+  return getRollupByAddress(fromAddress, env.CHAIN_ID);
+}
 
 /**
  * Determines if a direct count operation must be performed or the value can be obtained by using
@@ -22,17 +37,21 @@ export function requiresDirectCount({
   transactionAddresses,
   blockType,
 }: Filters) {
-  const addressFiltersCount = transactionAddresses?.length ?? 0;
-  const hasRollupAsAddress = !!getRollupFromAddressFilter(transactionAddresses);
+  const blockNumberRangeFilterEnabled = !!blockNumber;
   const reorgedFilterEnabled = !!blockType?.some;
+  const slotRangeFilterEnabled = !!blockSlot;
+  const addressFiltersCount = transactionAddresses?.length ?? 0;
+  const severalAddressesFilterEnabled = addressFiltersCount > 1;
+  const nonRollupAddressFilterEnabled =
+    addressFiltersCount === 1 &&
+    !getRollupFromAddressFilter(transactionAddresses);
 
-  // We
   return (
-    blockNumber ||
-    blockSlot ||
+    blockNumberRangeFilterEnabled ||
+    slotRangeFilterEnabled ||
     reorgedFilterEnabled ||
-    addressFiltersCount > 1 ||
-    (addressFiltersCount === 1 && !hasRollupAsAddress)
+    severalAddressesFilterEnabled ||
+    nonRollupAddressFilterEnabled
   );
 }
 

--- a/packages/api/src/utils/count.ts
+++ b/packages/api/src/utils/count.ts
@@ -3,7 +3,20 @@ import { toDailyDatePeriod } from "@blobscan/dayjs";
 import { getRollupFromAddressFilter } from "../middlewares/withFilters";
 import type { Filters } from "../middlewares/withFilters";
 
-export function hasToPerformCount({
+/**
+ * Determines if a direct count operation must be performed or the value can be obtained by using
+ * pre-calculated values from aggregated stats tables, based on the provided filters.
+ *
+ * Aggregated stats are not available for certain filters, including:
+ * - Reorged blocks (`blockType` filter)
+ * - Specific `blockNumber` or `blockSlot` ranges
+ * - Filters involving multiple addresses or non-rollup addresses
+ *
+ * This function checks for those cases and returns `true` if a direct count is needed.
+ *
+ * @returns A boolean indicating if a direct count is required.
+ */
+export function requiresDirectCount({
   blockNumber,
   blockSlot,
   transactionAddresses,
@@ -13,6 +26,7 @@ export function hasToPerformCount({
   const hasRollupAsAddress = !!getRollupFromAddressFilter(transactionAddresses);
   const reorgedFilterEnabled = !!blockType?.some;
 
+  // We
   return (
     blockNumber ||
     blockSlot ||

--- a/packages/api/test/blob.test.ts
+++ b/packages/api/test/blob.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { BlobDailyStats, BlobOverallStats, Prisma } from "@blobscan/db";
 import { fixtures } from "@blobscan/test";
 
-import type { Rollup } from "../enums";
+import type { Category, Rollup } from "../enums";
 import type { AppRouter } from "../src/app-router";
 import { appRouter } from "../src/app-router";
 import type { TRPCContext } from "../src/context";
@@ -191,8 +191,12 @@ describe("Blob router", async () => {
     });
 
     runFilterTests(async (filters) => {
-      const filtersRollup = (filters.rollup?.toUpperCase() ??
-        null) as Rollup | null;
+      const categoryFilter: Category | null =
+        filters.rollup === "null" ? "ROLLUP" : null;
+      const rollupFilter: Rollup | null =
+        filters.rollup === "null"
+          ? null
+          : ((filters.rollup?.toUpperCase() ?? null) as Rollup | null);
       const directCountRequired = requiresDirectCount(filters);
       let expectedTotalBlobs = 0;
 
@@ -216,8 +220,9 @@ describe("Blob router", async () => {
             dailyCounts.map(({ day, count }) =>
               createNewDailyStats({
                 day,
+                category: categoryFilter,
+                rollup: rollupFilter,
                 totalBlobs: count,
-                rollup: filtersRollup,
               })
             )
           );
@@ -225,8 +230,8 @@ describe("Blob router", async () => {
           expectedTotalBlobs = STATS_TOTAL_BLOBS;
 
           await createNewOverallStats({
-            category: null,
-            rollup: filtersRollup,
+            category: categoryFilter,
+            rollup: rollupFilter,
             totalBlobs: expectedTotalBlobs,
           });
         }

--- a/packages/api/test/blob.test.ts
+++ b/packages/api/test/blob.test.ts
@@ -130,12 +130,16 @@ describe("Blob router", async () => {
   describe("getCount", () => {
     it("should return the overall total blobs stat when no filters are provided", async () => {
       await ctx.prisma.blobOverallStats.populate();
+
       const { totalBlobs } = await caller.blob.getCount({});
 
       expect(totalBlobs).toBe(fixtures.canonicalBlobs.length);
     });
 
     runFilterTests(async (filters) => {
+      await ctx.prisma.blobDailyStats.populate();
+      await ctx.prisma.blobOverallStats.populate();
+
       const { totalBlobs } = await caller.blob.getCount(filters);
 
       expect(totalBlobs).toBe(getFilteredBlobs(filters).length);

--- a/packages/api/test/blob.test.ts
+++ b/packages/api/test/blob.test.ts
@@ -1,18 +1,25 @@
 import type { inferProcedureInput } from "@trpc/server";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import type { BlobDailyStats, BlobOverallStats, Prisma } from "@blobscan/db";
 import { fixtures } from "@blobscan/test";
 
+import type { Rollup } from "../enums";
 import type { AppRouter } from "../src/app-router";
 import { appRouter } from "../src/app-router";
 import type { TRPCContext } from "../src/context";
 import {
   createTestContext,
+  generateDailyCounts,
   runExpandsTestsSuite,
   runFiltersTestsSuite,
   runPaginationTestsSuite,
 } from "./helpers";
-import { getFilteredBlobs, runFilterTests } from "./test-suites/filters";
+import {
+  getFilteredBlobs,
+  requiresDirectCount,
+  runFilterTests,
+} from "./test-suites/filters";
 import { blobIdSchemaTestsSuite } from "./test-suites/schemas";
 
 type GetByIdInput = inferProcedureInput<AppRouter["blob"]["getByBlobId"]>;
@@ -128,21 +135,106 @@ describe("Blob router", async () => {
   });
 
   describe("getCount", () => {
+    // To test that the procedure retrieves the count from the stats table rather than
+    // performing a direct database count, we stored an arbitrary total blobs value in the stats table
+    // in each test, intentionally different from the actual number of blobs in the database.
+    // This setup allows us to verify that the procedure correctly uses the stats table count
+    // instead of performing a direct database count.
+    const STATS_TOTAL_BLOBS = 999999;
+
+    async function createNewOverallStats(
+      overallStats: Partial<BlobOverallStats>
+    ) {
+      const data: Prisma.BlobOverallStatsCreateManyInput = {
+        category: null,
+        rollup: null,
+        updatedAt: new Date(),
+        totalBlobs: 0,
+        totalBlobSize: 0,
+        totalUniqueBlobs: 0,
+        ...overallStats,
+      };
+
+      await ctx.prisma.blobOverallStats.create({
+        data,
+      });
+    }
+
+    async function createNewDailyStats(dailyStats: Partial<BlobDailyStats>) {
+      const data: Prisma.BlobDailyStatsCreateInput = {
+        day: new Date(),
+        category: null,
+        rollup: null,
+        totalBlobs: 0,
+        totalBlobSize: 0,
+        totalUniqueBlobs: 0,
+        ...dailyStats,
+      };
+
+      await ctx.prisma.blobDailyStats.create({
+        data,
+      });
+    }
+
     it("should return the overall total blobs stat when no filters are provided", async () => {
-      await ctx.prisma.blobOverallStats.populate();
+      const expectedTotalBlobs = STATS_TOTAL_BLOBS;
+
+      await createNewOverallStats({
+        category: null,
+        rollup: null,
+        totalBlobs: expectedTotalBlobs,
+      });
 
       const { totalBlobs } = await caller.blob.getCount({});
 
-      expect(totalBlobs).toBe(fixtures.canonicalBlobs.length);
+      expect(totalBlobs).toBe(expectedTotalBlobs);
     });
 
     runFilterTests(async (filters) => {
-      await ctx.prisma.blobDailyStats.populate();
-      await ctx.prisma.blobOverallStats.populate();
+      const filtersRollup = (filters.rollup?.toUpperCase() ??
+        null) as Rollup | null;
+      const directCountRequired = requiresDirectCount(filters);
+      let expectedTotalBlobs = 0;
+
+      if (directCountRequired) {
+        expectedTotalBlobs = getFilteredBlobs(filters).length;
+      } else {
+        const { startDate, endDate } = filters;
+        const dateFilterEnabled = startDate || endDate;
+
+        if (dateFilterEnabled) {
+          const dailyCounts = generateDailyCounts(
+            { from: startDate, to: endDate },
+            STATS_TOTAL_BLOBS
+          );
+          expectedTotalBlobs = dailyCounts.reduce(
+            (acc, { count }) => acc + count,
+            0
+          );
+
+          await Promise.all(
+            dailyCounts.map(({ day, count }) =>
+              createNewDailyStats({
+                day,
+                totalBlobs: count,
+                rollup: filtersRollup,
+              })
+            )
+          );
+        } else {
+          expectedTotalBlobs = STATS_TOTAL_BLOBS;
+
+          await createNewOverallStats({
+            category: null,
+            rollup: filtersRollup,
+            totalBlobs: expectedTotalBlobs,
+          });
+        }
+      }
 
       const { totalBlobs } = await caller.blob.getCount(filters);
 
-      expect(totalBlobs).toBe(getFilteredBlobs(filters).length);
+      expect(totalBlobs).toBe(expectedTotalBlobs);
     });
   });
 });

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 
 import { createBlobPropagator } from "@blobscan/blob-propagator/src/blob-propagator";
 import { createBlobStorageManager } from "@blobscan/blob-storage-manager";
+import type { DatePeriod } from "@blobscan/dayjs";
+import dayjs, { toDailyDate } from "@blobscan/dayjs";
 import { prisma } from "@blobscan/db";
 import type { Rollup } from "@blobscan/db";
 import { env } from "@blobscan/env";
@@ -321,4 +323,29 @@ export async function unauthorizedRPCCallTest(rpcCall: () => Promise<unknown>) {
       new TRPCError({ code: "UNAUTHORIZED" })
     );
   });
+}
+
+export function generateDailyCounts({ from, to }: DatePeriod, count: number) {
+  const dailyCounts: {
+    day: Date;
+    count: number;
+  }[] = [];
+  const maxDays = 10;
+  const startDate = from
+    ? dayjs(from)
+    : toDailyDate(dayjs(to).subtract(maxDays));
+  const endDate = to ? dayjs(to) : toDailyDate(dayjs(from).add(maxDays));
+
+  const days = endDate.diff(startDate, "days");
+
+  for (let i = 0; i < days; i++) {
+    const day = toDailyDate(startDate.add(i, "day")).toDate();
+
+    dailyCounts.push({
+      day,
+      count,
+    });
+  }
+
+  return dailyCounts;
 }

--- a/packages/api/test/test-suites/filters.ts
+++ b/packages/api/test/test-suites/filters.ts
@@ -124,12 +124,6 @@ export function runFilterTests(
       });
     });
 
-    it("should return the correct results when filtering by a 'null' rollup", async () => {
-      await assertFilters({
-        rollup: "null",
-      });
-    });
-
     it("should return the correct results when filtering by a start block", async () => {
       await assertFilters({
         startBlock: 1007,

--- a/packages/api/test/test-suites/filters.ts
+++ b/packages/api/test/test-suites/filters.ts
@@ -114,6 +114,28 @@ export function getFilteredBlobs(filters: FiltersSchema) {
   });
 }
 
+export function requiresDirectCount({
+  endBlock,
+  endSlot,
+  from,
+  to,
+  type,
+  startBlock,
+  startSlot,
+}: FiltersSchema) {
+  const blockNumberRangeFilterEnabled = !!startBlock || !!endBlock;
+  const reorgedFilterEnabled = type === "reorged";
+  const slotRangeFilterEnabled = !!startSlot || !!endSlot;
+  const addressFilterEnabled = !!from || !!to;
+
+  return (
+    blockNumberRangeFilterEnabled ||
+    reorgedFilterEnabled ||
+    slotRangeFilterEnabled ||
+    addressFilterEnabled
+  );
+}
+
 export function runFilterTests(
   assertFilters: (filters: FiltersSchema) => Promise<void>
 ) {

--- a/packages/api/test/test-suites/filters.ts
+++ b/packages/api/test/test-suites/filters.ts
@@ -146,6 +146,12 @@ export function runFilterTests(
       });
     });
 
+    it("should return the correct results when filtering by a 'null' rollup", async () => {
+      await assertFilters({
+        rollup: "null",
+      });
+    });
+
     it("should return the correct results when filtering by a start block", async () => {
       await assertFilters({
         startBlock: 1007,

--- a/packages/api/test/tx.test.ts
+++ b/packages/api/test/tx.test.ts
@@ -7,7 +7,7 @@ import type {
 } from "@blobscan/db";
 import { fixtures } from "@blobscan/test";
 
-import type { Rollup } from "../enums";
+import type { Category, Rollup } from "../enums";
 import type { TRPCContext } from "../src";
 import { appRouter } from "../src/app-router";
 import {
@@ -193,8 +193,12 @@ describe("Transaction router", async () => {
     });
 
     runFilterTests(async (filters) => {
-      const filtersRollup = (filters.rollup?.toUpperCase() ??
-        null) as Rollup | null;
+      const categoryFilter: Category | null =
+        filters.rollup === "null" ? "ROLLUP" : null;
+      const rollupFilter: Rollup | null =
+        filters.rollup === "null"
+          ? null
+          : ((filters.rollup?.toUpperCase() ?? null) as Rollup | null);
       const directCountRequired = requiresDirectCount(filters);
       let expectedTotalTransactions = 0;
 
@@ -219,7 +223,8 @@ describe("Transaction router", async () => {
               createNewDailyStats({
                 day,
                 totalTransactions: count,
-                rollup: filtersRollup,
+                category: categoryFilter,
+                rollup: rollupFilter,
               })
             )
           );
@@ -228,8 +233,8 @@ describe("Transaction router", async () => {
 
           await createNewOverallStats({
             totalTransactions: expectedTotalTransactions,
-            category: null,
-            rollup: filtersRollup,
+            category: categoryFilter,
+            rollup: rollupFilter,
           });
         }
       }

--- a/packages/api/test/tx.test.ts
+++ b/packages/api/test/tx.test.ts
@@ -1,16 +1,27 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import type {
+  Prisma,
+  TransactionDailyStats,
+  TransactionOverallStats,
+} from "@blobscan/db";
 import { fixtures } from "@blobscan/test";
 
+import type { Rollup } from "../enums";
 import type { TRPCContext } from "../src";
 import { appRouter } from "../src/app-router";
 import {
   createTestContext,
+  generateDailyCounts,
   runExpandsTestsSuite,
   runFiltersTestsSuite,
   runPaginationTestsSuite,
 } from "./helpers";
-import { getFilteredTransactions, runFilterTests } from "./test-suites/filters";
+import {
+  getFilteredTransactions,
+  requiresDirectCount,
+  runFilterTests,
+} from "./test-suites/filters";
 
 describe("Transaction router", async () => {
   let caller: ReturnType<typeof appRouter.createCaller>;
@@ -18,6 +29,7 @@ describe("Transaction router", async () => {
 
   beforeAll(async () => {
     ctx = await createTestContext();
+
     caller = appRouter.createCaller(ctx);
   });
 
@@ -96,21 +108,139 @@ describe("Transaction router", async () => {
   });
 
   describe("getCount", () => {
-    it("should return the correct count when no filters are provided", async () => {
-      await ctx.prisma.transactionOverallStats.populate();
-      await ctx.prisma.transactionDailyStats.populate();
+    // To test that the procedure retrieves the count from the stats table rather than
+    // performing a direct database count, we stored an arbitrary total blobs value in the stats table
+    // in each test, intentionally different from the actual number of blobs in the database.
+    // This setup allows us to verify that the procedure correctly uses the stats table count
+    // instead of performing a direct database count.
+
+    const STATS_TOTAL_TRANSACTIONS = 999999;
+
+    async function createNewOverallStats(
+      overallStats: Partial<TransactionOverallStats>
+    ) {
+      const data: Prisma.TransactionOverallStatsCreateManyInput = {
+        category: null,
+        rollup: null,
+        totalTransactions: 0,
+        avgBlobFee: 0,
+        avgBlobGasPrice: 0,
+        avgBlobMaxFee: 0,
+        avgMaxBlobGasFee: 0,
+        totalBlobAsCalldataFee: 0,
+        totalBlobAsCalldataGasUsed: 0,
+        totalBlobAsCalldataMaxFees: 0,
+        totalBlobFee: 0,
+        totalBlobMaxFees: 0,
+        totalBlobGasPrice: 0,
+        totalBlobGasUsed: 0,
+        totalBlobMaxGasFees: 0,
+        totalUniqueReceivers: 0,
+        totalUniqueSenders: 0,
+        avgBlobAsCalldataFee: 0,
+        avgBlobAsCalldataMaxFee: 0,
+        updatedAt: new Date(),
+        ...overallStats,
+      };
+
+      await ctx.prisma.transactionOverallStats.create({
+        data,
+      });
+    }
+
+    async function createNewDailyStats(
+      dailyStats: Partial<TransactionDailyStats>
+    ) {
+      const data: Prisma.TransactionDailyStatsCreateManyInput = {
+        day: new Date(),
+        category: null,
+        rollup: null,
+        totalTransactions: 0,
+        avgBlobFee: 0,
+        avgBlobGasPrice: 0,
+        avgBlobMaxFee: 0,
+        avgMaxBlobGasFee: 0,
+        totalBlobAsCalldataFee: 0,
+        totalBlobAsCalldataGasUsed: 0,
+        totalBlobAsCalldataMaxFees: 0,
+        totalBlobFee: 0,
+        totalBlobMaxFees: 0,
+        totalBlobGasUsed: 0,
+        totalUniqueReceivers: 0,
+        totalUniqueSenders: 0,
+        avgBlobAsCalldataFee: 0,
+        avgBlobAsCalldataMaxFee: 0,
+        ...dailyStats,
+      };
+
+      await ctx.prisma.transactionDailyStats.create({
+        data,
+      });
+    }
+
+    it("should count txs correctly when no filters are provided", async () => {
+      const expectedTotalTransactions = STATS_TOTAL_TRANSACTIONS;
+
+      await createNewOverallStats({
+        category: null,
+        rollup: null,
+        totalTransactions: expectedTotalTransactions,
+      });
 
       const { totalTransactions } = await caller.tx.getCount({});
 
-      expect(totalTransactions).toBe(fixtures.canonicalTxs.length);
+      expect(totalTransactions).toBe(expectedTotalTransactions);
     });
 
     runFilterTests(async (filters) => {
-      await ctx.prisma.transactionOverallStats.populate();
-      await ctx.prisma.transactionDailyStats.populate();
+      const filtersRollup = (filters.rollup?.toUpperCase() ??
+        null) as Rollup | null;
+      const directCountRequired = requiresDirectCount(filters);
+      let expectedTotalTransactions = 0;
+
+      if (directCountRequired) {
+        expectedTotalTransactions = getFilteredTransactions(filters).length;
+      } else {
+        const { startDate, endDate } = filters;
+        const dateFilterEnabled = startDate || endDate;
+
+        if (dateFilterEnabled) {
+          const dailyCounts = generateDailyCounts(
+            { from: startDate, to: endDate },
+            STATS_TOTAL_TRANSACTIONS
+          );
+          expectedTotalTransactions = dailyCounts.reduce(
+            (acc, { count }) => acc + count,
+            0
+          );
+
+          await Promise.all(
+            dailyCounts.map(({ day, count }) =>
+              createNewDailyStats({
+                day,
+                totalTransactions: count,
+                rollup: filtersRollup,
+              })
+            )
+          );
+        } else {
+          expectedTotalTransactions = STATS_TOTAL_TRANSACTIONS;
+
+          await createNewOverallStats({
+            totalTransactions: expectedTotalTransactions,
+            category: null,
+            rollup: filtersRollup,
+          });
+        }
+      }
+
       const { totalTransactions } = await caller.tx.getCount(filters);
 
-      expect(totalTransactions).toBe(getFilteredTransactions(filters).length);
+      const expectMsg = directCountRequired
+        ? "Expect count to match direct count"
+        : "Expect count to match precomputed aggregated stats value";
+
+      expect(totalTransactions, expectMsg).toBe(expectedTotalTransactions);
     });
   });
 });

--- a/packages/api/test/tx.test.ts
+++ b/packages/api/test/tx.test.ts
@@ -94,7 +94,7 @@ describe("Transaction router", async () => {
   });
 
   describe("getCount", () => {
-    it("should return the overall total transactions stat when no filters are provided", async () => {
+    it("should return the correct count when no filters are provided", async () => {
       await ctx.prisma.transactionOverallStats.populate();
 
       const { totalTransactions } = await caller.tx.getCount({});

--- a/packages/api/test/tx.test.ts
+++ b/packages/api/test/tx.test.ts
@@ -52,6 +52,8 @@ describe("Transaction router", async () => {
     });
 
     it("should get the total number of transactions for a rollup", async () => {
+      await ctx.prisma.transactionOverallStats.populate();
+
       const expectedTotalTransactions = await ctx.prisma.transaction.count({
         where: {
           rollup: "BASE",
@@ -96,6 +98,7 @@ describe("Transaction router", async () => {
   describe("getCount", () => {
     it("should return the correct count when no filters are provided", async () => {
       await ctx.prisma.transactionOverallStats.populate();
+      await ctx.prisma.transactionDailyStats.populate();
 
       const { totalTransactions } = await caller.tx.getCount({});
 
@@ -103,6 +106,8 @@ describe("Transaction router", async () => {
     });
 
     runFilterTests(async (filters) => {
+      await ctx.prisma.transactionOverallStats.populate();
+      await ctx.prisma.transactionDailyStats.populate();
       const { totalTransactions } = await caller.tx.getCount(filters);
 
       expect(totalTransactions).toBe(getFilteredTransactions(filters).length);

--- a/packages/dayjs/src/date.ts
+++ b/packages/dayjs/src/date.ts
@@ -51,17 +51,22 @@ export function toDailyDate(
   return date_[startOfOrEndOfDay]("day");
 }
 
-export function toDailyDatePeriod(
-  datePeriodLike?: DatePeriodLike
-): Required<DatePeriod> {
-  const { from, to } = datePeriodLike || {};
+export function toDailyDatePeriod(datePeriodLike: DatePeriodLike): DatePeriod {
+  const { from, to } = datePeriodLike;
 
   if (from && to && dayjs(to).isBefore(from)) {
     throw new Error(`Invalid date period. Start date is after end date`);
   }
 
-  return {
-    from: from ? toDailyDate(from, "startOf").toDate() : MIN_DATE,
-    to: to ? toDailyDate(to, "endOf").toDate() : new Date(),
-  };
+  const datePeriod: DatePeriod = {};
+
+  if (from) {
+    datePeriod.from = toDailyDate(from, "startOf").toDate();
+  }
+
+  if (to) {
+    datePeriod.to = toDailyDate(to, "endOf").toDate();
+  }
+
+  return datePeriod;
 }

--- a/packages/db/prisma/extensions/stats.ts
+++ b/packages/db/prisma/extensions/stats.ts
@@ -8,7 +8,7 @@ import {
   aggregateTxOverallStats,
 } from "@prisma/client/sql";
 
-import { toDailyDatePeriod } from "@blobscan/dayjs";
+import { MIN_DATE, toDailyDatePeriod } from "@blobscan/dayjs";
 
 import { curryPrismaExtensionFnSpan } from "../instrumentation";
 import type { BlockNumberRange, DatePeriodLike } from "../types";
@@ -32,7 +32,9 @@ export const statsExtension = Prisma.defineExtension((prisma) =>
           });
         },
         populate(dailyDatePeriod?: DatePeriodLike) {
-          const { from, to } = toDailyDatePeriod(dailyDatePeriod);
+          const { from: from = MIN_DATE, to: to = new Date() } = dailyDatePeriod
+            ? toDailyDatePeriod(dailyDatePeriod)
+            : {};
 
           return prisma.$queryRawTyped(aggregateBlobDailyStats(from, to));
         },
@@ -56,7 +58,9 @@ export const statsExtension = Prisma.defineExtension((prisma) =>
           });
         },
         populate(dailyDatePeriod?: DatePeriodLike) {
-          const { from, to } = toDailyDatePeriod(dailyDatePeriod);
+          const { from: from = MIN_DATE, to: to = new Date() } = dailyDatePeriod
+            ? toDailyDatePeriod(dailyDatePeriod)
+            : {};
 
           return prisma.$queryRawTyped(aggregateBlockDailyStats(from, to));
         },
@@ -82,7 +86,9 @@ export const statsExtension = Prisma.defineExtension((prisma) =>
           });
         },
         async populate(dailyDatePeriod?: DatePeriodLike) {
-          const { from, to } = toDailyDatePeriod(dailyDatePeriod);
+          const { from: from = MIN_DATE, to: to = new Date() } = dailyDatePeriod
+            ? toDailyDatePeriod(dailyDatePeriod)
+            : {};
 
           return prisma.$queryRawTyped(aggregateTxDailyStats(from, to));
         },

--- a/packages/db/test/helpers/suites/daily-stats.ts
+++ b/packages/db/test/helpers/suites/daily-stats.ts
@@ -46,7 +46,8 @@ function getExpectedAggregatedDays(
   model: DailyStatsModel,
   datePeriodLike: DatePeriodLike
 ) {
-  const { from, to } = toDailyDatePeriod(datePeriodLike);
+  const { from: from = MIN_DATE, to: to = new Date() } =
+    toDailyDatePeriod(datePeriodLike);
   let elementTimestamps: string[];
 
   switch (model) {

--- a/packages/test/src/fixtures/index.ts
+++ b/packages/test/src/fixtures/index.ts
@@ -265,6 +265,7 @@ export const fixtures = {
       prisma.transaction.deleteMany(),
       prisma.addressCategoryInfo.deleteMany(),
       prisma.address.deleteMany(),
+      prisma.addressCategoryInfo.deleteMany(),
       prisma.block.deleteMany(),
       prisma.blockDailyStats.deleteMany(),
       prisma.transactionDailyStats.deleteMany(),

--- a/packages/test/src/fixtures/index.ts
+++ b/packages/test/src/fixtures/index.ts
@@ -8,7 +8,7 @@ import type {
 } from "@prisma/client";
 
 import type { DatePeriodLike } from "@blobscan/dayjs";
-import dayjs, { toDailyDatePeriod } from "@blobscan/dayjs";
+import dayjs, { MIN_DATE, toDailyDatePeriod } from "@blobscan/dayjs";
 
 import POSTGRES_DATA from "./postgres/data.json";
 
@@ -165,15 +165,14 @@ export const fixtures = {
   getBlocks({ blockNumberRange, datePeriod }: GetOptions) {
     if (!datePeriod && !blockNumberRange) return fixtures.canonicalBlocks;
 
-    const dailyDatePeriod = toDailyDatePeriod(datePeriod);
+    const { from = MIN_DATE, to = new Date() } = datePeriod
+      ? toDailyDatePeriod(datePeriod)
+      : {};
     const fromBlock = blockNumberRange?.from ?? 0;
     const toBlock = blockNumberRange?.to ?? Number.MAX_SAFE_INTEGER;
 
     return fixtures.canonicalBlocks.filter((b) => {
-      const isInDateRange = dayjs(b.timestamp).isBetween(
-        dailyDatePeriod.from,
-        dailyDatePeriod.to
-      );
+      const isInDateRange = dayjs(b.timestamp).isBetween(from, to);
       const isInBlockNumberRange = b.number >= fromBlock && b.number <= toBlock;
 
       return isInDateRange && isInBlockNumberRange;


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It optimizes the retrieval of element counts when filters are applied. By obtaining the total number of elements from the stats tables—specifically when filtering by rollup, category, or timestamp—we can utilize data from the overall or daily stats tables.

#### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):
