### PR TITLE
feat(rollups): add missing sepolia rollups

### DIFF
--- a/.changeset/famous-dodos-fetch.md
+++ b/.changeset/famous-dodos-fetch.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/rollups": minor
+---
+
+Added missing Sepolia sequencer addresses for the following rollups: ARBITRUM, BASE, LINEA and OPTIMISM

--- a/packages/rollups/src/index.ts
+++ b/packages/rollups/src/index.ts
@@ -35,10 +35,16 @@ export const ADDRESS_TO_ROLLUP_MAPPINGS: Map<
     11155111,
     new Map([
       ["0xb2248390842d3c4acf1d8a893954afc0eac586e5", Rollup.ARBITRUM],
+      ["0x1fb1494f5135bb01a698fb3e863dd12f876bb085", Rollup.ARBITRUM],
+      ["0x07f0e1ec1ce152b075fda4a827a9f17851086b25", Rollup.ARBITRUM],
+      ["0xfc56e7272eebbba5bc6c544e159483c4a38f8ba3", Rollup.BASE],
       ["0x6cdebe940bc0f26850285caca097c11c33103e47", Rollup.BASE],
       ["0xf15dc770221b99c98d4aaed568f2ab04b9d16e42", Rollup.KROMA],
       ["0x47c63d1e391fcb3dcdc40c4d7fa58adb172f8c38", Rollup.LINEA],
+      ["0x88584cf948cd51267f220edd9e21e67ccf3fcfa8", Rollup.LINEA],
       ["0x8f23bb38f531600e5d8fddaaec41f13fab46e98c", Rollup.OPTIMISM],
+      ["0xdf50ccaa4467b61b51d8ed86320d8ca67a56265e", Rollup.OPTIMISM],
+      ["0xe14b3f075ad9377689daf659e04a2a99a4acede4", Rollup.OPTIMISM],
       ["0x2d567ece699eabe5afcd141edb7a4f2d0d6ce8a0", Rollup.SCROLL],
       ["0x5b98b836969a60fec50fa925905dd1d382a7db43", Rollup.STARKNET],
       ["0x4e6bd53883107b063c502ddd49f9600dc51b3ddc", Rollup.MODE],
@@ -49,15 +55,23 @@ export const ADDRESS_TO_ROLLUP_MAPPINGS: Map<
   [100, new Map()],
 ]);
 
-export const ROLLUP_TO_ADDRESS_MAPPINGS = new Map(
+export const ROLLUP_TO_ADDRESSES_MAPPINGS = new Map(
   [...ADDRESS_TO_ROLLUP_MAPPINGS.entries()].map(
     ([chainId, addressToRollupMapping]) => [
       chainId,
       new Map(
-        [...addressToRollupMapping.entries()].map(([address, rollup]) => [
-          rollup,
-          address,
-        ])
+        [...addressToRollupMapping.entries()].reduce<Map<Rollup, string[]>>(
+          (rollupToAddresses, [address, rollup]) => {
+            if (!rollupToAddresses.has(rollup)) {
+              rollupToAddresses.set(rollup, []);
+            }
+
+            rollupToAddresses.get(rollup)?.push(address);
+
+            return rollupToAddresses;
+          },
+          new Map()
+        )
       ),
     ]
   )
@@ -87,11 +101,11 @@ export function getRollupByAddress(
   return addressToRollupMapping.get(normalizedAddress) || null;
 }
 
-export function getAddressByRollup(
+export function getAddressesByRollup(
   rollup: Rollup,
   chainId: number
-): string | null {
-  const rollupMapping = ROLLUP_TO_ADDRESS_MAPPINGS.get(chainId);
+): string[] | null {
+  const rollupMapping = ROLLUP_TO_ADDRESSES_MAPPINGS.get(chainId);
 
   if (!rollupMapping) {
     return null;

--- a/packages/rollups/test/rollups.test.ts
+++ b/packages/rollups/test/rollups.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Rollup } from "@blobscan/db/prisma/enums";
 
 import {
-  getAddressByRollup,
+  getAddressesByRollup,
   getChainRollups,
   getRollupByAddress,
 } from "../src";
@@ -24,29 +24,47 @@ describe("Rollups", () => {
     expect(getRollupByAddress(address, chainId)).toBe(null);
   });
 
-  it("should retrieve an address by its rollup correctly", () => {
+  it("should retrieve a single address by its rollup correctly", () => {
     const chainId = 11155111;
     const rollup = Rollup.MODE;
-    const expectedAddress = "0x4e6bd53883107b063c502ddd49f9600dc51b3ddc";
+    const expectedAddress = ["0x4e6bd53883107b063c502ddd49f9600dc51b3ddc"];
 
-    expect(getAddressByRollup(rollup, chainId)).toBe(expectedAddress);
+    expect(getAddressesByRollup(rollup, chainId)).toEqual(expectedAddress);
+  });
+
+  it("should retrieve a set of addresses by its rollup correctly", () => {
+    const chainId = 11155111;
+    const rollup = Rollup.ARBITRUM;
+    const expectedAddresses = [
+      "0xb2248390842d3c4acf1d8a893954afc0eac586e5",
+      "0x1fb1494f5135bb01a698fb3e863dd12f876bb085",
+      "0x07f0e1ec1ce152b075fda4a827a9f17851086b25",
+    ];
+
+    expect(getAddressesByRollup(rollup, chainId)).toEqual(expectedAddresses);
   });
 
   it("should return null when retrieving an address by a rollup that does not exists", () => {
     const chainId = 11155111;
     const rollup = Rollup.BOBA;
 
-    expect(getAddressByRollup(rollup, chainId)).toBe(null);
+    expect(getAddressesByRollup(rollup, chainId)).toBe(null);
   });
 
   it("should get all chain's rollups correctly", () => {
     const chainId = 11155111;
     const expectedRollups = [
       ["0xb2248390842d3c4acf1d8a893954afc0eac586e5", Rollup.ARBITRUM],
+      ["0x1fb1494f5135bb01a698fb3e863dd12f876bb085", Rollup.ARBITRUM],
+      ["0x07f0e1ec1ce152b075fda4a827a9f17851086b25", Rollup.ARBITRUM],
+      ["0xfc56e7272eebbba5bc6c544e159483c4a38f8ba3", Rollup.BASE],
       ["0x6cdebe940bc0f26850285caca097c11c33103e47", Rollup.BASE],
       ["0xf15dc770221b99c98d4aaed568f2ab04b9d16e42", Rollup.KROMA],
       ["0x47c63d1e391fcb3dcdc40c4d7fa58adb172f8c38", Rollup.LINEA],
+      ["0x88584cf948cd51267f220edd9e21e67ccf3fcfa8", Rollup.LINEA],
       ["0x8f23bb38f531600e5d8fddaaec41f13fab46e98c", Rollup.OPTIMISM],
+      ["0xdf50ccaa4467b61b51d8ed86320d8ca67a56265e", Rollup.OPTIMISM],
+      ["0xe14b3f075ad9377689daf659e04a2a99a4acede4", Rollup.OPTIMISM],
       ["0x2d567ece699eabe5afcd141edb7a4f2d0d6ce8a0", Rollup.SCROLL],
       ["0x5b98b836969a60fec50fa925905dd1d382a7db43", Rollup.STARKNET],
       ["0x4e6bd53883107b063c502ddd49f9600dc51b3ddc", Rollup.MODE],


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
It adds missing Sepolia's rollup sequencer addresses for the following: arbitrum, base, Linea and optimism. 

#### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):
