### PR TITLE
Display `id` in `SearchResultItem` when label is absent

### DIFF
--- a/.changeset/smart-bears-sin.md
+++ b/.changeset/smart-bears-sin.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed an issue where the search result wasn't being displayed properly

--- a/apps/web/src/components/SearchInput/SearchResults.tsx
+++ b/apps/web/src/components/SearchInput/SearchResults.tsx
@@ -65,7 +65,7 @@ const SearchResultItem: React.FC<SearchResultItemProps> = function ({
                 {categoryLabel}
               </div>
             )}
-            {label}
+            {label ? label : id}
           </span>
           {reorg && (
             <Badge variant="primary" className="text-xs">


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Display `id` in `SearchResultItem` when label is absent

### Related Issue (Optional)
Closes #618
