### PR TITLE
fix(api): add reorg handling fixes

### DIFF
--- a/.changeset/brown-emus-hunt.md
+++ b/.changeset/brown-emus-hunt.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": patch
+---
+
+Added address category info constraints to transaction model

--- a/.changeset/khaki-rules-applaud.md
+++ b/.changeset/khaki-rules-applaud.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Resolved an issue where blocks flagged as reorged remained marked as reorged after being reindexed

--- a/.changeset/rotten-bears-bathe.md
+++ b/.changeset/rotten-bears-bathe.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": patch
+---
+
+Created indexes for block number fields

--- a/packages/api/src/routers/indexer/indexData.ts
+++ b/packages/api/src/routers/indexer/indexData.ts
@@ -125,6 +125,13 @@ export const indexData = jwtAuthedProcedure
       const dbAddressCategoryInfos = createDBAddressCategoryInfo(dbTxs);
 
       operations.push(
+        // We may be indexing a block that was marked as a reorg previously,
+        // so we delete any possible rows from the fork table
+        prisma.transactionFork.deleteMany({
+          where: {
+            blockHash: input.block.hash,
+          },
+        }),
         prisma.block.upsert({
           where: { hash: input.block.hash },
           create: {

--- a/packages/api/test/indexer.test.ts
+++ b/packages/api/test/indexer.test.ts
@@ -622,6 +622,32 @@ describe("Indexer router", async () => {
         ).resolves.toBeUndefined();
       });
 
+      it("should reindex a block previously marked as reorged correctly", async () => {
+        const blockHash = INPUT.block.hash;
+        const blockTxHashes = INPUT.transactions.map((tx) => tx.hash);
+
+        // Marked the block as reorged
+        await authorizedContext.prisma.transactionFork.createMany({
+          data: blockTxHashes.map((hash) => ({
+            hash,
+            blockHash,
+          })),
+        });
+
+        // Reindex the block
+        await authorizedCaller.indexer.indexData(INPUT);
+
+        const forkTxs = await authorizedContext.prisma.transactionFork.findMany(
+          {
+            where: {
+              blockHash,
+            },
+          }
+        );
+
+        expect(forkTxs, "Block still has forked transactions").toEqual([]);
+      });
+
       testValidError(
         "should fail when receiving an empty array of transactions",
         async () => {

--- a/packages/db/prisma/migrations/20241119092259_add_address_category_info_fks/migration.sql
+++ b/packages/db/prisma/migrations/20241119092259_add_address_category_info_fks/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "transaction" ADD CONSTRAINT "transaction_from_id_category_fkey" FOREIGN KEY ("from_id", "category") REFERENCES "address_category_info"("address", "category") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "transaction" ADD CONSTRAINT "transaction_to_id_category_fkey" FOREIGN KEY ("to_id", "category") REFERENCES "address_category_info"("address", "category") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20241120051254_add_block_number_reference_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20241120051254_add_block_number_reference_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "address_category_info_first_block_number_as_receiver_idx" ON "address_category_info"("first_block_number_as_receiver");
+
+-- CreateIndex
+CREATE INDEX "address_category_info_first_block_number_as_sender_idx" ON "address_category_info"("first_block_number_as_sender");
+
+-- CreateIndex
+CREATE INDEX "blob_first_block_number_idx" ON "blob"("first_block_number");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4,7 +4,7 @@
 generator client {
   provider        = "prisma-client-js"
   // rhel-openssl-1.0.x is required by Vercel
-  binaryTargets = ["native", "rhel-openssl-1.0.x", "linux-musl-openssl-3.0.x"]
+  binaryTargets   = ["native", "rhel-openssl-1.0.x", "linux-musl-openssl-3.0.x"]
   previewFeatures = ["tracing", "metrics", "typedSql"]
 }
 
@@ -83,7 +83,9 @@ model AddressCategoryInfo {
   firstBlockNumberAsReceiver Int?      @map("first_block_number_as_receiver")
   firstBlockNumberAsSender   Int?      @map("first_block_number_as_sender")
 
-  addressEntity Address @relation(fields: [address], references: [address])
+  addressEntity          Address       @relation(fields: [address], references: [address])
+  transactionsAsSender   Transaction[] @relation("senderAddressCategoryInfoRelation")
+  transactionsAsReceiver Transaction[] @relation("receiverAddressCategoryInfoRelation")
 
   @@unique([address, category])
   @@map("address_category_info")
@@ -176,10 +178,12 @@ model Transaction {
   updatedAt             DateTime @default(now()) @map("updated_at")
   decodedFields         Json     @default("{}") @map("decoded_fields")
 
-  blobs BlobsOnTransactions[]
-  block Block                 @relation(fields: [blockHash], references: [hash])
-  from  Address               @relation("senderAddressRelation", fields: [fromId], references: [address])
-  to    Address               @relation("receiverAddressRelation", fields: [toId], references: [address])
+  blobs                   BlobsOnTransactions[]
+  block                   Block                 @relation(fields: [blockHash], references: [hash])
+  from                    Address               @relation("senderAddressRelation", fields: [fromId], references: [address])
+  to                      Address               @relation("receiverAddressRelation", fields: [toId], references: [address])
+  fromAddressCategoryInfo AddressCategoryInfo   @relation("senderAddressCategoryInfoRelation", fields: [fromId, category], references: [address, category])
+  toAddressCategoryInfo   AddressCategoryInfo   @relation("receiverAddressCategoryInfoRelation", fields: [toId, category], references: [address, category])
 
   transactionForks TransactionFork[]
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -88,6 +88,8 @@ model AddressCategoryInfo {
   transactionsAsReceiver Transaction[] @relation("receiverAddressCategoryInfoRelation")
 
   @@unique([address, category])
+  @@index([firstBlockNumberAsReceiver])
+  @@index([firstBlockNumberAsSender])
   @@map("address_category_info")
 }
 
@@ -116,6 +118,7 @@ model Blob {
   dataStorageReferences BlobDataStorageReference[]
   transactions          BlobsOnTransactions[]
 
+  @@index([firstBlockNumber])
   @@index([proof])
   @@index([insertedAt])
   @@map("blob")


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
**It builds on top of #635** 

This PR introduces improvements to the reorg handling logic:

- It removes forked transaction records from blocks that were flagged as reorged and later reindexed.
- It clears block number references from records associated with reorged blocks. This involves setting the `firstBlockNumber` fields to `null` on both the address category and blob models.

#### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):
