### PR TITLE
Minor Documentation Update: Typo Correction

### DIFF
--- a/apps/docs/src/app/docs/running-blobscan-kurtosis/page.md
+++ b/apps/docs/src/app/docs/running-blobscan-kurtosis/page.md
@@ -11,7 +11,7 @@ nextjs:
 [Kurtosis](https://www.kurtosis.com/) is a tool for packaging and launching environments of containerized services where you want them and with one liners.
 
 There is also a [Kurtosis' ethereum-package](https://github.com/ethpandaops/ethereum-package) maintained by ethPandaOps, which makes it really easy to
-spin up up a local PoS Ethereum testnet with blobscan as an additional service, so you can explore blobs sent in your local network.
+spin up a local PoS Ethereum testnet with blobscan as an additional service, so you can explore blobs sent in your local network.
 
 ```bash
 kurtosis clean -a && kurtosis run github.com/ethpandaops/ethereum-package --image-download always '{"additional_services": ["blobscan"]}'


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Fixed a typo in the `page.md` file. Removed the redundant word "up" in the sentence:  
**"spin up up a local PoS Ethereum testnet..."** → **"spin up a local PoS Ethereum testnet..."**

#### Motivation and Context (Optional)
Fixing the typo improves the readability of the documentation and reduces potential confusion.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c6503584-fa9f-4296-8a74-3dbcf3b80c43)
