### PR TITLE
fix(api): add reorg handling fixes

### DIFF
--- a/.changeset/brown-emus-hunt.md
+++ b/.changeset/brown-emus-hunt.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": patch
+---
+
+Added address category info constraints to transaction model

--- a/.changeset/khaki-rules-applaud.md
+++ b/.changeset/khaki-rules-applaud.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Resolved an issue where blocks flagged as reorged remained marked as reorged after being reindexed

--- a/.changeset/rotten-bears-bathe.md
+++ b/.changeset/rotten-bears-bathe.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": patch
+---
+
+Created indexes for block number fields

--- a/apps/web/src/components/Dropdown/Option.tsx
+++ b/apps/web/src/components/Dropdown/Option.tsx
@@ -8,7 +8,7 @@ interface OptionProps {
 }
 
 export const Option: React.FC<OptionProps> = function ({ option }) {
-  const { prefix, label, value } = option;
+  const { label, value } = option;
   const formattedValue = Array.isArray(value) ? value.join(", ") : value;
 
   return (
@@ -18,11 +18,8 @@ export const Option: React.FC<OptionProps> = function ({ option }) {
     >
       {({ selected }) => (
         <div className="flex items-center justify-between gap-3">
-          <div className="flex flex-row items-center gap-2">
-            {prefix && prefix}
-            <span className="block truncate text-sm">
-              {label ? label : formattedValue}
-            </span>
+          <div className="truncate text-sm">
+            {label ? label : formattedValue}
           </div>
           {selected && (
             <CheckIcon

--- a/apps/web/src/components/Dropdown/Option.tsx
+++ b/apps/web/src/components/Dropdown/Option.tsx
@@ -7,19 +7,21 @@ interface OptionProps {
   option: OptionType;
 }
 
-export const Option: React.FC<OptionProps> = function (props) {
-  const { prefix, label, value } = props.option;
+export const Option: React.FC<OptionProps> = function ({ option }) {
+  const { prefix, label, value } = option;
+  const formattedValue = Array.isArray(value) ? value.join(", ") : value;
+
   return (
     <ListboxOption
       className={`relative cursor-pointer select-none px-4 py-2 text-contentSecondary-light hover:bg-controlActive-light data-[selected]:font-semibold data-[selected]:text-content-light dark:text-contentSecondary-dark  hover:dark:bg-controlActive-dark data-[selected]:dark:font-semibold data-[selected]:dark:text-content-dark`}
-      value={props.option}
+      value={option}
     >
       {({ selected }) => (
         <div className="flex items-center justify-between gap-3">
           <div className="flex flex-row items-center gap-2">
             {prefix && prefix}
             <span className="block truncate text-sm">
-              {label ? label : value}
+              {label ? label : formattedValue}
             </span>
           </div>
           {selected && (

--- a/apps/web/src/components/Dropdown/index.tsx
+++ b/apps/web/src/components/Dropdown/index.tsx
@@ -13,7 +13,7 @@ import useOverflow from "~/hooks/useOverflow";
 import { Option } from "./Option";
 
 export interface Option {
-  value: string | number;
+  value: string | number | string[] | number[];
   label?: ReactNode;
   prefix?: ReactNode;
   selectedLabel?: ReactNode;
@@ -69,10 +69,12 @@ export const Dropdown: React.FC<DropdownProps> = function ({
               {hasSelectedValue ? (
                 Array.isArray(selected) ? (
                   <div className="flex flex-row items-center gap-1">
-                    {selected.map((s) => {
+                    {selected.map(({ selectedLabel, label, value }) => {
                       return (
-                        <Fragment key={s.value}>
-                          {s.selectedLabel ? s.selectedLabel : s.label}
+                        <Fragment
+                          key={Array.isArray(value) ? value.join("-") : value}
+                        >
+                          {selectedLabel ? selectedLabel : label}
                         </Fragment>
                       );
                     })}

--- a/apps/web/src/components/Dropdown/index.tsx
+++ b/apps/web/src/components/Dropdown/index.tsx
@@ -15,7 +15,6 @@ import { Option } from "./Option";
 export interface Option {
   value: string | number | string[] | number[];
   label?: ReactNode;
-  prefix?: ReactNode;
   selectedLabel?: ReactNode;
 }
 

--- a/apps/web/src/components/Filters/RollupFilter.tsx
+++ b/apps/web/src/components/Filters/RollupFilter.tsx
@@ -26,14 +26,18 @@ export const ROLLUP_OPTIONS: Option[] = [
     selectedLabel: <Badge size="sm">None</Badge>,
     label: "None",
   },
-  ...rollups.map(([name, addresses]) => {
+  ...rollups.map<Option>(([name, addresses]) => {
     return {
       value: addresses,
       selectedLabel: (
         <RollupBadge rollup={name.toLowerCase() as Rollup} size="sm" />
       ),
-      prefix: <RollupIcon rollup={name.toLowerCase() as Rollup} />,
-      label: capitalize(name),
+      label: (
+        <div className="flex flex-row items-center gap-2">
+          <RollupIcon rollup={name.toLowerCase() as Rollup} />
+          <div>{capitalize(name)}</div>
+        </div>
+      ),
     };
   }),
 ];

--- a/apps/web/src/components/Filters/RollupFilter.tsx
+++ b/apps/web/src/components/Filters/RollupFilter.tsx
@@ -26,14 +26,14 @@ export const ROLLUP_OPTIONS: Option[] = [
     selectedLabel: <Badge size="sm">None</Badge>,
     label: "None",
   },
-  ...rollups.map(([rollupAddress, rollupName]) => {
+  ...rollups.map(([name, addresses]) => {
     return {
-      value: rollupAddress,
+      value: addresses,
       selectedLabel: (
-        <RollupBadge rollup={rollupName.toLowerCase() as Rollup} size="sm" />
+        <RollupBadge rollup={name.toLowerCase() as Rollup} size="sm" />
       ),
-      prefix: <RollupIcon rollup={rollupName.toLowerCase() as Rollup} />,
-      label: capitalize(rollupName),
+      prefix: <RollupIcon rollup={name.toLowerCase() as Rollup} />,
+      label: capitalize(name),
     };
   }),
 ];

--- a/apps/web/src/components/Filters/index.tsx
+++ b/apps/web/src/components/Filters/index.tsx
@@ -94,7 +94,7 @@ export const Filters: FC = function () {
         query.rollup = rollups[0]?.value;
       } else {
         query.from = rollups
-          .map((r) => r.value)
+          .flatMap((r) => r.value)
           .join(FROM_ADDRESSES_FORMAT_SEPARATOR);
       }
     }

--- a/packages/api/src/routers/indexer/indexData.ts
+++ b/packages/api/src/routers/indexer/indexData.ts
@@ -125,6 +125,13 @@ export const indexData = jwtAuthedProcedure
       const dbAddressCategoryInfos = createDBAddressCategoryInfo(dbTxs);
 
       operations.push(
+        // We may be indexing a block that was marked as a reorg previously,
+        // so we delete any possible rows from the fork table
+        prisma.transactionFork.deleteMany({
+          where: {
+            blockHash: input.block.hash,
+          },
+        }),
         prisma.block.upsert({
           where: { hash: input.block.hash },
           create: {

--- a/packages/api/test/indexer.test.ts
+++ b/packages/api/test/indexer.test.ts
@@ -622,6 +622,32 @@ describe("Indexer router", async () => {
         ).resolves.toBeUndefined();
       });
 
+      it("should reindex a block previously marked as reorged correctly", async () => {
+        const blockHash = INPUT.block.hash;
+        const blockTxHashes = INPUT.transactions.map((tx) => tx.hash);
+
+        // Marked the block as reorged
+        await authorizedContext.prisma.transactionFork.createMany({
+          data: blockTxHashes.map((hash) => ({
+            hash,
+            blockHash,
+          })),
+        });
+
+        // Reindex the block
+        await authorizedCaller.indexer.indexData(INPUT);
+
+        const forkTxs = await authorizedContext.prisma.transactionFork.findMany(
+          {
+            where: {
+              blockHash,
+            },
+          }
+        );
+
+        expect(forkTxs, "Block still has forked transactions").toEqual([]);
+      });
+
       testValidError(
         "should fail when receiving an empty array of transactions",
         async () => {

--- a/packages/db/prisma/migrations/20241119092259_add_address_category_info_fks/migration.sql
+++ b/packages/db/prisma/migrations/20241119092259_add_address_category_info_fks/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "transaction" ADD CONSTRAINT "transaction_from_id_category_fkey" FOREIGN KEY ("from_id", "category") REFERENCES "address_category_info"("address", "category") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "transaction" ADD CONSTRAINT "transaction_to_id_category_fkey" FOREIGN KEY ("to_id", "category") REFERENCES "address_category_info"("address", "category") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20241120051254_add_block_number_reference_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20241120051254_add_block_number_reference_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "address_category_info_first_block_number_as_receiver_idx" ON "address_category_info"("first_block_number_as_receiver");
+
+-- CreateIndex
+CREATE INDEX "address_category_info_first_block_number_as_sender_idx" ON "address_category_info"("first_block_number_as_sender");
+
+-- CreateIndex
+CREATE INDEX "blob_first_block_number_idx" ON "blob"("first_block_number");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4,7 +4,7 @@
 generator client {
   provider        = "prisma-client-js"
   // rhel-openssl-1.0.x is required by Vercel
-  binaryTargets = ["native", "rhel-openssl-1.0.x", "linux-musl-openssl-3.0.x"]
+  binaryTargets   = ["native", "rhel-openssl-1.0.x", "linux-musl-openssl-3.0.x"]
   previewFeatures = ["tracing", "metrics", "typedSql"]
 }
 
@@ -83,7 +83,9 @@ model AddressCategoryInfo {
   firstBlockNumberAsReceiver Int?      @map("first_block_number_as_receiver")
   firstBlockNumberAsSender   Int?      @map("first_block_number_as_sender")
 
-  addressEntity Address @relation(fields: [address], references: [address])
+  addressEntity          Address       @relation(fields: [address], references: [address])
+  transactionsAsSender   Transaction[] @relation("senderAddressCategoryInfoRelation")
+  transactionsAsReceiver Transaction[] @relation("receiverAddressCategoryInfoRelation")
 
   @@unique([address, category])
   @@map("address_category_info")
@@ -176,10 +178,12 @@ model Transaction {
   updatedAt             DateTime @default(now()) @map("updated_at")
   decodedFields         Json     @default("{}") @map("decoded_fields")
 
-  blobs BlobsOnTransactions[]
-  block Block                 @relation(fields: [blockHash], references: [hash])
-  from  Address               @relation("senderAddressRelation", fields: [fromId], references: [address])
-  to    Address               @relation("receiverAddressRelation", fields: [toId], references: [address])
+  blobs                   BlobsOnTransactions[]
+  block                   Block                 @relation(fields: [blockHash], references: [hash])
+  from                    Address               @relation("senderAddressRelation", fields: [fromId], references: [address])
+  to                      Address               @relation("receiverAddressRelation", fields: [toId], references: [address])
+  fromAddressCategoryInfo AddressCategoryInfo   @relation("senderAddressCategoryInfoRelation", fields: [fromId, category], references: [address, category])
+  toAddressCategoryInfo   AddressCategoryInfo   @relation("receiverAddressCategoryInfoRelation", fields: [toId, category], references: [address, category])
 
   transactionForks TransactionFork[]
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -88,6 +88,8 @@ model AddressCategoryInfo {
   transactionsAsReceiver Transaction[] @relation("receiverAddressCategoryInfoRelation")
 
   @@unique([address, category])
+  @@index([firstBlockNumberAsReceiver])
+  @@index([firstBlockNumberAsSender])
   @@map("address_category_info")
 }
 
@@ -116,6 +118,7 @@ model Blob {
   dataStorageReferences BlobDataStorageReference[]
   transactions          BlobsOnTransactions[]
 
+  @@index([firstBlockNumber])
   @@index([proof])
   @@index([insertedAt])
   @@map("blob")

--- a/packages/rollups/src/index.ts
+++ b/packages/rollups/src/index.ts
@@ -77,8 +77,8 @@ export const ROLLUP_TO_ADDRESSES_MAPPINGS = new Map(
   )
 );
 
-export function getChainRollups(chainId: number): [string, Rollup][] {
-  const addressToRollupMapping = ADDRESS_TO_ROLLUP_MAPPINGS.get(chainId);
+export function getChainRollups(chainId: number): [Rollup, string[]][] {
+  const addressToRollupMapping = ROLLUP_TO_ADDRESSES_MAPPINGS.get(chainId);
 
   if (!addressToRollupMapping) {
     return [];

--- a/packages/rollups/test/rollups.test.ts
+++ b/packages/rollups/test/rollups.test.ts
@@ -54,21 +54,41 @@ describe("Rollups", () => {
   it("should get all chain's rollups correctly", () => {
     const chainId = 11155111;
     const expectedRollups = [
-      ["0xb2248390842d3c4acf1d8a893954afc0eac586e5", Rollup.ARBITRUM],
-      ["0x1fb1494f5135bb01a698fb3e863dd12f876bb085", Rollup.ARBITRUM],
-      ["0x07f0e1ec1ce152b075fda4a827a9f17851086b25", Rollup.ARBITRUM],
-      ["0xfc56e7272eebbba5bc6c544e159483c4a38f8ba3", Rollup.BASE],
-      ["0x6cdebe940bc0f26850285caca097c11c33103e47", Rollup.BASE],
-      ["0xf15dc770221b99c98d4aaed568f2ab04b9d16e42", Rollup.KROMA],
-      ["0x47c63d1e391fcb3dcdc40c4d7fa58adb172f8c38", Rollup.LINEA],
-      ["0x88584cf948cd51267f220edd9e21e67ccf3fcfa8", Rollup.LINEA],
-      ["0x8f23bb38f531600e5d8fddaaec41f13fab46e98c", Rollup.OPTIMISM],
-      ["0xdf50ccaa4467b61b51d8ed86320d8ca67a56265e", Rollup.OPTIMISM],
-      ["0xe14b3f075ad9377689daf659e04a2a99a4acede4", Rollup.OPTIMISM],
-      ["0x2d567ece699eabe5afcd141edb7a4f2d0d6ce8a0", Rollup.SCROLL],
-      ["0x5b98b836969a60fec50fa925905dd1d382a7db43", Rollup.STARKNET],
-      ["0x4e6bd53883107b063c502ddd49f9600dc51b3ddc", Rollup.MODE],
-      ["0x3cd868e221a3be64b161d596a7482257a99d857f", Rollup.ZORA],
+      [
+        Rollup.ARBITRUM,
+        [
+          "0xb2248390842d3c4acf1d8a893954afc0eac586e5",
+          "0x1fb1494f5135bb01a698fb3e863dd12f876bb085",
+          "0x07f0e1ec1ce152b075fda4a827a9f17851086b25",
+        ],
+      ],
+      [
+        Rollup.BASE,
+        [
+          "0xfc56e7272eebbba5bc6c544e159483c4a38f8ba3",
+          "0x6cdebe940bc0f26850285caca097c11c33103e47",
+        ],
+      ],
+      [Rollup.KROMA, ["0xf15dc770221b99c98d4aaed568f2ab04b9d16e42"]],
+      [
+        Rollup.LINEA,
+        [
+          "0x47c63d1e391fcb3dcdc40c4d7fa58adb172f8c38",
+          "0x88584cf948cd51267f220edd9e21e67ccf3fcfa8",
+        ],
+      ],
+      [
+        Rollup.OPTIMISM,
+        [
+          "0x8f23bb38f531600e5d8fddaaec41f13fab46e98c",
+          "0xdf50ccaa4467b61b51d8ed86320d8ca67a56265e",
+          "0xe14b3f075ad9377689daf659e04a2a99a4acede4",
+        ],
+      ],
+      [Rollup.SCROLL, ["0x2d567ece699eabe5afcd141edb7a4f2d0d6ce8a0"]],
+      [Rollup.STARKNET, ["0x5b98b836969a60fec50fa925905dd1d382a7db43"]],
+      [Rollup.MODE, ["0x4e6bd53883107b063c502ddd49f9600dc51b3ddc"]],
+      [Rollup.ZORA, ["0x3cd868e221a3be64b161d596a7482257a99d857f"]],
     ];
 
     expect(getChainRollups(chainId)).toEqual(expectedRollups);


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR introduces improvements to the reorg handling logic:

- It removes forked transaction records from blocks that were flagged as reorged and later reindexed.
- It clears block number references from records associated with reorged blocks. This involves setting the `firstBlockNumber` fields to `null` on both the address category and blob models.


#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
