### PR TITLE
fix(web): set Rollup filter for multiple `from` addresses from query params

### DIFF
--- a/.changeset/eighty-clouds-end.md
+++ b/.changeset/eighty-clouds-end.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed an issue where the Rollup filter was not being set correctly from query parameters

--- a/apps/web/src/components/Filters/RollupFilter.tsx
+++ b/apps/web/src/components/Filters/RollupFilter.tsx
@@ -20,27 +20,28 @@ type RollupFilterProps = {
 const chainId = getChainIdByName(env.NEXT_PUBLIC_NETWORK_NAME);
 const rollups = chainId ? getChainRollups(chainId) : [];
 
-export const ROLLUP_OPTIONS: Option[] = [
+export const ROLLUP_OPTIONS = [
   {
     value: "null",
     selectedLabel: <Badge size="sm">None</Badge>,
     label: "None",
   },
-  ...rollups.map<Option>(([name, addresses]) => {
-    return {
-      value: addresses,
-      selectedLabel: (
-        <RollupBadge rollup={name.toLowerCase() as Rollup} size="sm" />
-      ),
-      label: (
-        <div className="flex flex-row items-center gap-2">
-          <RollupIcon rollup={name.toLowerCase() as Rollup} />
-          <div>{capitalize(name)}</div>
-        </div>
-      ),
-    };
-  }),
-];
+  ...rollups.map(
+    ([name, addresses]) =>
+      ({
+        value: addresses,
+        selectedLabel: (
+          <RollupBadge rollup={name.toLowerCase() as Rollup} size="sm" />
+        ),
+        label: (
+          <div className="flex flex-row items-center gap-2">
+            <RollupIcon rollup={name.toLowerCase() as Rollup} />
+            <div>{capitalize(name)}</div>
+          </div>
+        ),
+      } satisfies Option)
+  ),
+] satisfies Option[];
 
 export const RollupFilter: FC<RollupFilterProps> = function ({
   onChange,

--- a/apps/web/src/components/Filters/index.tsx
+++ b/apps/web/src/components/Filters/index.tsx
@@ -162,11 +162,19 @@ export const Filters: FC = function () {
     if (rollup || from) {
       const rollupOptions = ROLLUP_OPTIONS.filter((opt) => {
         const fromAddresses = from?.split(FROM_ADDRESSES_FORMAT_SEPARATOR);
+        const rollupOptionAddresses = Array.isArray(opt.value)
+          ? opt.value
+          : [opt.value];
+
         return (
-          opt.value === rollup || fromAddresses?.includes(opt.value as string)
+          opt.value === rollup ||
+          rollupOptionAddresses.filter((rollupAddress) =>
+            fromAddresses?.includes(rollupAddress)
+          ).length > 0
         );
       });
 
+      console.log(rollupOptions);
       if (rollupOptions) {
         newFilters.rollups = rollupOptions;
       }


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It fixes an issue where the rollup filter wasn't being properly set given a `from` query param containing several addresses

#### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):
