### PR TITLE
chore: removes unused expo-tools extension from recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "expo.vscode-expo-tools",
     "Prisma.prisma",
     "yoavbls.pretty-ts-errors"
   ]


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Removes unused `expo-tools` extension from recommendations