### PR TITLE
fix: ether display overflow on small screens in Transaction details page

### DIFF
--- a/.changeset/quick-suns-switch.md
+++ b/.changeset/quick-suns-switch.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed Ether display overflow in Transaction details card for small screens.

--- a/apps/web/src/components/Displays/StandardEtherUnitDisplay.tsx
+++ b/apps/web/src/components/Displays/StandardEtherUnitDisplay.tsx
@@ -13,7 +13,7 @@ export const StandardEtherUnitDisplay = ({
   opts = {},
 }: StandardEtherUnitDisplayProps) => {
   return (
-    <div className="flex items-center justify-start gap-1">
+    <div className="flex items-center justify-start gap-1 max-sm:flex-col max-sm:items-start max-sm:gap-0">
       <EtherUnitDisplay amount={amount} toUnit="ether" opts={opts} />
       <span className="text-contentTertiary-light dark:text-contentTertiary-dark">
         (


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
To avoid the overflow with big values, we can set the display information into column for smaller devices


### Related Issue 
Closes #638 

### Screenshots 
| BEFORE | AFTER  |
|----------|----------|
| <img width="341" alt="image" src="https://github.com/user-attachments/assets/3b4deaa1-ba6b-405c-aafc-4c17cee68be9"> | <img width="340" alt="image" src="https://github.com/user-attachments/assets/3ce2dc89-f25b-42d6-9a8d-c3d42d1018dc"> |
