### PR TITLE
Simplify block table rollups list

### DIFF
--- a/.changeset/proud-cars-try.md
+++ b/.changeset/proud-cars-try.md
@@ -2,4 +2,4 @@
 "@blobscan/web": minor
 ---
 
-Simplified rollups list in blocks table by making them uniques.
+Improved the block row rollup icons column by removing duplicated icons.

--- a/.changeset/proud-cars-try.md
+++ b/.changeset/proud-cars-try.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Simplified rollups list in blocks table by making them uniques.

--- a/apps/web/src/pages/blocks.tsx
+++ b/apps/web/src/pages/blocks.tsx
@@ -193,15 +193,17 @@ const Blocks: NextPage = function () {
               {
                 item: (
                   <div className="relative flex">
-                    {transactions.map((tx, i) => {
-                      return tx.rollup ? (
-                        <div key={i} className="-ml-1 first-of-type:ml-0">
-                          <RollupIcon rollup={tx.rollup} />
-                        </div>
-                      ) : (
-                        <></>
-                      );
-                    })}
+                    {[...new Set(transactions.map((tx) => tx.rollup))].map(
+                      (rollup, i) => {
+                        return rollup ? (
+                          <div key={i} className="-ml-1 first-of-type:ml-0">
+                            <RollupIcon rollup={rollup} />
+                          </div>
+                        ) : (
+                          <></>
+                        );
+                      }
+                    )}
                   </div>
                 ),
               },


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
The `blocks` table only shows unique rollups in the list. To check-in details the `rollup` associated with each `transaction` the user can check the expanded table for each row.

### Related Issue 
Closes #659 

### Screenshots 
| BEFORE | AFTER |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/710cdf0e-df6a-4fd0-b749-365b1019ff00)  | <img width="238" alt="image" src="https://github.com/user-attachments/assets/9022825a-0a07-4502-9ae0-4fe587cdedcc">  |
