### PR TITLE
Fix home page charts misalignment

### DIFF
--- a/.changeset/hip-suits-buy.md
+++ b/.changeset/hip-suits-buy.md
@@ -2,4 +2,4 @@
 "@blobscan/web": patch
 ---
 
-Fixed misalignment for charts in home page"
+Fixed misalignment for charts in home page.

--- a/.changeset/hip-suits-buy.md
+++ b/.changeset/hip-suits-buy.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed misalignment for charts in home page"

--- a/apps/web/src/components/Cards/ChartCard.tsx
+++ b/apps/web/src/components/Cards/ChartCard.tsx
@@ -33,7 +33,7 @@ export const ChartCard: FC<ChartCardProps> = function ({
   const { isEmpty, isLoading } = getSeriesDataState(options.series);
 
   return (
-    <Card className="overflow-visible" compact>
+    <Card className="h-full overflow-visible" compact>
       <div className="flex-start -mb-2 ml-2 flex font-semibold dark:text-warmGray-50">
         {title ?? <Skeleton width={150} />}
       </div>


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [X] I have filled out the description and linked the related issues.

### Description
The charts from the home page are now aligned with the stats data.

### Related Issue (
Closes #660 

### Screenshots 
| BEFORE | AFTER |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/4988a498-4565-4f9d-af79-3e76912dfcaa) | <img alt="image" src="https://github.com/user-attachments/assets/004bb410-7507-41ad-a68f-906fcba04557">  |
