### PR TITLE
fix: fixes client side PostHog events capturing and adds extra data to the metadata

### DIFF
--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -28,7 +28,7 @@ if (typeof window !== "undefined" && env.NEXT_PUBLIC_POSTHOG_ID) {
     api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
     person_profiles: "identified_only",
     loaded: (posthog) => {
-      if (env.NODE_ENV === "development") {
+      if (window.location.hostname.includes("localhost")) {
         posthog.debug();
       }
     },

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -9,11 +9,10 @@ import type {
 import cookie from "cookie";
 import jwt from "jsonwebtoken";
 
-import { BlobPropagator, getBlobPropagator } from "@blobscan/blob-propagator";
-import {
-  BlobStorageManager,
-  getBlobStorageManager,
-} from "@blobscan/blob-storage-manager";
+import type { BlobPropagator } from "@blobscan/blob-propagator";
+import { getBlobPropagator } from "@blobscan/blob-propagator";
+import type { BlobStorageManager } from "@blobscan/blob-storage-manager";
+import { getBlobStorageManager } from "@blobscan/blob-storage-manager";
 import { prisma } from "@blobscan/db";
 import { env } from "@blobscan/env";
 
@@ -119,6 +118,15 @@ export function createTRPCContext(
           );
         }
 
+        let pathname: string | undefined;
+        let query: string | undefined;
+
+        if (opts.req.url) {
+          const url = new URL(opts.req.url, env.BLOBSCAN_API_BASE_URL);
+          pathname = url.pathname;
+          query = url.searchParams.toString();
+        }
+
         posthog.capture({
           distinctId,
           event: "trpc_request",
@@ -126,7 +134,9 @@ export function createTRPCContext(
             $ip: getIP(opts.req),
             scope,
             $current_url: opts.req.url,
-            method: opts.req.method,
+            network: env.NETWORK_NAME,
+            pathname,
+            query,
           },
         });
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This update fixes the client-side capturing of `PostHog` events and adds additional data to the metadata.

The issue with client-side `PostHog` event capturing arose because we were attempting to read a server-side environment variable within the `loaded` function.

Additionally, we now save the network name, as well as the `pathname` and `queryString` in the `PostHog` metadata.

### Related Issue (Optional)
#650