### PR TITLE
fix(posthog): send $host in trpc_request events

### DIFF
--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -132,6 +132,7 @@ export function createTRPCContext(
           event: "trpc_request",
           properties: {
             $ip: getIP(opts.req),
+            $host: env.BLOBSCAN_API_BASE_URL,
             scope,
             $current_url: opts.req.url,
             network: env.NETWORK_NAME,


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Set $host property for our custom trpc_request event

#### Motivation and Context (Optional)
We need a way to differentiate the host which originated the event

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
