### PR TITLE
Fix typo CHANGELOG.md

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Minor Changes
 
-- [#592](https://github.com/Blobscan/blobscan/pull/592) [`76bd799`](https://github.com/Blobscan/blobscan/commit/76bd7990ea36b2826924cdbec6ddc660e96b1a17) Thanks [@xFJA](https://github.com/xFJA)! - Added the posibility to filter by multiple `from` addresses
+- [#592](https://github.com/Blobscan/blobscan/pull/592) [`76bd799`](https://github.com/Blobscan/blobscan/commit/76bd7990ea36b2826924cdbec6ddc660e96b1a17) Thanks [@xFJA](https://github.com/xFJA)! - Added the possibility to filter by multiple `from` addresses
 
 ## 0.14.0
 


### PR DESCRIPTION
## Title: Fix Typo in `CHANGELOG.md` (posibility -> possibility)

### Description:
This pull request corrects the typo "posibility" to "possibility" in the `CHANGELOG.md` file.

### Changes:
- Replaced "posibility" with "possibility."
