### PR TITLE
Fix Grammar Issues in Documentation and Comments

### DIFF
--- a/apps/docs/src/app/docs/running-blobscan-k8s/page.md
+++ b/apps/docs/src/app/docs/running-blobscan-k8s/page.md
@@ -9,7 +9,7 @@ nextjs:
 A set of Helm charts are provided to run multiple Blobscan components on Kubernetes.
 
 {% callout title="Tip" %}
-If you want to try the Helm Charts without setting up a whole Kubernetes clusters, you can create a local [Kind](https://kind.sigs.k8s.io/) cluster.
+If you want to try the Helm Charts without setting up a whole Kubernetes cluster, you can create a local [Kind](https://kind.sigs.k8s.io/) cluster.
 {% /callout %}
 
 ```bash

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,5 +1,5 @@
 // This file configures the initialization of Sentry on the client.
-// The config you add here will be used whenever a users loads a page in their browser.
+// The config you add here will be used whenever a user loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";


### PR DESCRIPTION
Changes:
1. apps/docs/src/app/docs/running-blobscan-k8s/page.md
- clusters -> cluster
Reason: Fixed plural to singular as referring to single Kubernetes cluster setup

2. apps/web/sentry.client.config.ts  
- users -> user
Reason: Corrected plural to singular in comment as it describes single user action