### PR TITLE
chore(api): replace hardcoded weavevm base url

### DIFF
--- a/.changeset/unlucky-chairs-smell.md
+++ b/.changeset/unlucky-chairs-smell.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Added support for parameterizing the WeaveVm blob data storage reference base URL

--- a/apps/docs/src/app/docs/environment/page.md
+++ b/apps/docs/src/app/docs/environment/page.md
@@ -29,42 +29,42 @@ nextjs:
 
 ## Blobscan API
 
-| Variable                             | Description                                                                                        | Required                        | Default value              |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------- |
-| `CHAIN_ID`                           | EVM chain id                                                                                       | Yes                             | `1`                        |
-| `DATABASE_URL`                       | Postgresql database URI                                                                            | Yes                             | (empty)                    |
-| `REDIS_URI`                          | Redis host                                                                                         | Yes                             | `redis://localhost:6379/1` |
-| `SECRET_KEY`                         | Shared key used for JWT authentication with the indexer                                            | Yes                             | (empty)                    |
-| `NETWORK_NAME`                       | Network's name (valid values are: `mainnet`, `holesky`, `sepolia`, `gnosis`, `chiado`, `devnet`)   | No                              | `mainnet`                  |
-| `BLOBSCAN_API_BASE_URL`              | API domain                                                                                         | No                              | `http://localhost:3001`    |
-| `BLOBSCAN_API_PORT`                  | API port                                                                                           | No                              | `3001`                     |
-| `DENCUN_FORK_SLOT`                   | Custom slot when blobs are activated (use when `NETWORK_NAME=devnet`)                              | No                              | (empty)                    |
-| `METRICS_ENABLED`                    | Expose the /metrics endpoint                                                                       | No                              | `false`                    |
-| `TRACES_ENABLED`                     | Enable instrumentation of functions and sending traces to a collector                              | No                              | `false`                    |
-| `NODE_ENV`                           | Used in Node.js applications to specify the environment in which the application is running        | No                              | (empty)                    |
-| `SENTRY_DSN_API`                     | Sentry DSN                                                                                         | No                              | (empty)                    |
-| `GOOGLE_SERVICE_KEY`                 | Google Cloud service key                                                                           | No                              | (empty)                    |
-| `GOOGLE_STORAGE_ENABLED`             | Store blobs in Google Cloud Storage                                                                | No                              | `false`                    |
-| `GOOGLE_STORAGE_API_ENDPOINT`        | Google Cloud API endpoint (for development)                                                        | No                              | (empty)                    |
-| `GOOGLE_STORAGE_BUCKET_NAME`         | Google Cloud Storage bucket name                                                                   | No                              | (empty)                    |
-| `GOOGLE_STORAGE_PROJECT_ID`          | Google Cloud project ID                                                                            | No                              | (empty)                    |
-| `POSTGRES_STORAGE_ENABLED`           | Store blobs in postgres database (default storage)                                                 | No                              | `false`                    |
-| `SWARM_DEFERRED_UPLOAD`              | Determines if the uploaded data should be sent to the network immediately or in a deferred fashion | No                              | `true`                     |
-| `SWARM_STORAGE_ENABLED`              | Store blobs in Ethereum Swarm                                                                      | No                              | `false`                    |
-| `SWARM_BATCH_ID`                     | Batch ID of the Ethereum Swarm stamp                                                               | If `SWARM_STORAGE_ENABLED=true` | (empty)                    |
-| `BEE_ENDPOINT`                       | Bee endpoint                                                                                       | No                              | (empty)                    |
-| `FILE_SYSTEM_STORAGE_ENABLED`        | Store blobs in filesystem                                                                          | No                              | `false`                    |
-| `FILE_SYSTEM_STORAGE_PATH`           | Store blobs in this path                                                                           | No                              | `/tmp/blobscan-blobs`      |
-| `WEAVEVM_STORAGE_ENABLED`            | Weavevm storage usage                                                                              | No                              | `false`                    |
-| `WEAVEVM_STORAGE_API_BASE_URL`       | Weavevm API base url                                                                               | No                              | (empty)                    |
-| `WEAVEVM_API_KEY`                    | API key required to authenticate requests to the WeaveVM blob storage reference updater endpoint   | No                              | (empty)                    |
-| `STATS_SYNCER_DAILY_CRON_PATTERN`    | Cron pattern for the daily stats job                                                               | No                              | `30 0 * * * *`             |
-| `STATS_SYNCER_OVERALL_CRON_PATTERN`  | Cron pattern for the overall stats job                                                             | No                              | `*/15 * * * *`             |
-| `SWARM_STAMP_CRON_PATTERN`           | Cron pattern for swarm job                                                                         | No                              | `*/15 * * * *`             |
-| `BLOB_PROPAGATOR_COMPLETED_JOBS_AGE` | Remove completed jobs after the specified number of seconds (default: 1 day)                       | No                              | `86400`                    |
-| `BLOB_PROPAGATOR_FAILED_JOBS_AGE`    | Remove completed jobs after the specified number of seconds (default: 7 days)                      | No                              | `604800`                   |
-| `POSTHOG_ID`                         | PostHog project API key used for tracking events and analytics                                     | No                              | (empty)                    |
-| `POSTHOG_HOST`                       | Host URL for the PostHog instance used for analytics tracking                                      | No                              | `https://us.i.posthog.com` |
+| Variable                             | Description                                                                                        | Required                        | Default value                  |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------ |
+| `CHAIN_ID`                           | EVM chain id                                                                                       | Yes                             | `1`                            |
+| `DATABASE_URL`                       | Postgresql database URI                                                                            | Yes                             | (empty)                        |
+| `REDIS_URI`                          | Redis host                                                                                         | Yes                             | `redis://localhost:6379/1`     |
+| `SECRET_KEY`                         | Shared key used for JWT authentication with the indexer                                            | Yes                             | (empty)                        |
+| `NETWORK_NAME`                       | Network's name (valid values are: `mainnet`, `holesky`, `sepolia`, `gnosis`, `chiado`, `devnet`)   | No                              | `mainnet`                      |
+| `BLOBSCAN_API_BASE_URL`              | API domain                                                                                         | No                              | `http://localhost:3001`        |
+| `BLOBSCAN_API_PORT`                  | API port                                                                                           | No                              | `3001`                         |
+| `DENCUN_FORK_SLOT`                   | Custom slot when blobs are activated (use when `NETWORK_NAME=devnet`)                              | No                              | (empty)                        |
+| `METRICS_ENABLED`                    | Expose the /metrics endpoint                                                                       | No                              | `false`                        |
+| `TRACES_ENABLED`                     | Enable instrumentation of functions and sending traces to a collector                              | No                              | `false`                        |
+| `NODE_ENV`                           | Used in Node.js applications to specify the environment in which the application is running        | No                              | (empty)                        |
+| `SENTRY_DSN_API`                     | Sentry DSN                                                                                         | No                              | (empty)                        |
+| `GOOGLE_SERVICE_KEY`                 | Google Cloud service key                                                                           | No                              | (empty)                        |
+| `GOOGLE_STORAGE_ENABLED`             | Store blobs in Google Cloud Storage                                                                | No                              | `false`                        |
+| `GOOGLE_STORAGE_API_ENDPOINT`        | Google Cloud API endpoint (for development)                                                        | No                              | (empty)                        |
+| `GOOGLE_STORAGE_BUCKET_NAME`         | Google Cloud Storage bucket name                                                                   | No                              | (empty)                        |
+| `GOOGLE_STORAGE_PROJECT_ID`          | Google Cloud project ID                                                                            | No                              | (empty)                        |
+| `POSTGRES_STORAGE_ENABLED`           | Store blobs in postgres database (default storage)                                                 | No                              | `false`                        |
+| `SWARM_DEFERRED_UPLOAD`              | Determines if the uploaded data should be sent to the network immediately or in a deferred fashion | No                              | `true`                         |
+| `SWARM_STORAGE_ENABLED`              | Store blobs in Ethereum Swarm                                                                      | No                              | `false`                        |
+| `SWARM_BATCH_ID`                     | Batch ID of the Ethereum Swarm stamp                                                               | If `SWARM_STORAGE_ENABLED=true` | (empty)                        |
+| `BEE_ENDPOINT`                       | Bee endpoint                                                                                       | No                              | (empty)                        |
+| `FILE_SYSTEM_STORAGE_ENABLED`        | Store blobs in filesystem                                                                          | No                              | `false`                        |
+| `FILE_SYSTEM_STORAGE_PATH`           | Store blobs in this path                                                                           | No                              | `/tmp/blobscan-blobs`          |
+| `WEAVEVM_STORAGE_ENABLED`            | Weavevm storage usage                                                                              | No                              | `false`                        |
+| `WEAVEVM_STORAGE_API_BASE_URL`       | Weavevm API base url                                                                               | No                              | `https://blobscan.wvm.network` |
+| `WEAVEVM_API_KEY`                    | API key required to authenticate requests to the WeaveVM blob storage reference updater endpoint   | No                              | (empty)                        |
+| `STATS_SYNCER_DAILY_CRON_PATTERN`    | Cron pattern for the daily stats job                                                               | No                              | `30 0 * * * *`                 |
+| `STATS_SYNCER_OVERALL_CRON_PATTERN`  | Cron pattern for the overall stats job                                                             | No                              | `*/15 * * * *`                 |
+| `SWARM_STAMP_CRON_PATTERN`           | Cron pattern for swarm job                                                                         | No                              | `*/15 * * * *`                 |
+| `BLOB_PROPAGATOR_COMPLETED_JOBS_AGE` | Remove completed jobs after the specified number of seconds (default: 1 day)                       | No                              | `86400`                        |
+| `BLOB_PROPAGATOR_FAILED_JOBS_AGE`    | Remove completed jobs after the specified number of seconds (default: 7 days)                      | No                              | `604800`                       |
+| `POSTHOG_ID`                         | PostHog project API key used for tracking events and analytics                                     | No                              | (empty)                        |
+| `POSTHOG_HOST`                       | Host URL for the PostHog instance used for analytics tracking                                      | No                              | `https://us.i.posthog.com`     |
 
 ## Blobscan indexer
 

--- a/packages/api/src/utils/serializers.ts
+++ b/packages/api/src/utils/serializers.ts
@@ -51,7 +51,7 @@ export function buildBlobDataUrl(
       return `${env.BLOBSCAN_API_BASE_URL}/blobs/${blobDataUri}/data`;
     }
     case "WEAVEVM": {
-      return `https://blobscan.shuttleapp.rs/v1/blob/${blobDataUri}`;
+      return `${env.WEAVEVM_STORAGE_API_BASE_URL}/v1/blob/${blobDataUri}`;
     }
   }
 }

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -58,7 +58,10 @@ export const env = createEnv({
       GOOGLE_STORAGE_PROJECT_ID: z.string().optional(),
       GOOGLE_SERVICE_KEY: z.string().optional(),
       WEAVEVM_STORAGE_ENABLED: booleanSchema.default("false"),
-      WEAVEVM_STORAGE_API_BASE_URL: z.string().url().optional(),
+      WEAVEVM_STORAGE_API_BASE_URL: z
+        .string()
+        .url()
+        .default("https://blobscan.wvm.network"),
       WEAVEVM_API_KEY: z.string().optional(),
       LOG_LEVEL: z
         .enum(["debug", "http", "info", "warn", "error"])


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR updates the returned blob data storage weavevm references by replacing the hardcoded base url for `WEAVEVM_STORAGE_API_BASE_URL` env var

It also sets a default value for `WEAVEVM_STORAGE_API_BASE_URL`
#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
