### PR TITLE
docs: Fix incorrect description for -q, --queue in page.md

### DIFF
--- a/apps/docs/src/app/docs/clis/page.md
+++ b/apps/docs/src/app/docs/clis/page.md
@@ -55,7 +55,7 @@ Remove Command
 Options
 
   -h, --help                 Print this usage guide.
-  -q, --queue queue          Queue to retry failed jobs from. Valid values are
+  -q, --queue queue          Queue to remove failed jobs from. Valid values are
                              finalizer, google, postgres or swarm.
   -b, --blobHash blob-hash   Blob hash of the failed jobs to retry.
   -f, --force                Force removal of jobs by obliterating the selected


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

In the "Remove Command" section, the description for the `-q, --queue` option incorrectly states that it is used to "retry failed jobs." However, this command is intended for removing tasks, not retrying them.

I've updated the description to accurately reflect its purpose:  

```bash
Queue to remove failed jobs from. Valid values are finalizer, google, postgres or swarm.
```  
