### PR TITLE
docs: Fix typo in technology name Update page.md

### DIFF
--- a/apps/docs/src/app/docs/storages/page.md
+++ b/apps/docs/src/app/docs/storages/page.md
@@ -14,7 +14,7 @@ Blobscan can be configured to use any of the following blob storages:
 - File system
 - Google Cloud Storage
 - PostgreSQL
-- [Weavevm](https://www.wvm.dev/) (currently supports blob reading only)
+- [WeaveVM](https://www.wvm.dev/) (currently supports blob reading only)
 
 By default all storages are disabled and you must enable at least one in order to run Blobscan. This is done using [environment variables](/docs/environment).
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

A typo in the name of the technology. It should be `WeaveVM` (with uppercase "VM") since it stands for "Virtual Machine." 
