### PR TITLE
refactor(env): replace conditionalRequiredSchema and requiredStorageConfigSchema with requireIfEnvEnabled

### DIFF
--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -102,10 +102,7 @@ export const env = createEnv({
 
       // Google Cloud Storage
       GOOGLE_STORAGE_ENABLED: booleanSchema.default("false"),
-      GOOGLE_STORAGE_PROJECT_ID: z
-        .string()
-        .optional()
-        .superRefine(requireIfEnvEnabled("GOOGLE_STORAGE_ENABLED")),
+      GOOGLE_STORAGE_PROJECT_ID: z.string().optional(),
       GOOGLE_STORAGE_API_ENDPOINT: z
         .string()
         .optional()

--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -42,21 +42,3 @@ export const blobStorageSchema = z.enum([
   "POSTGRES",
   "SWARM",
 ] as const);
-
-export function conditionalRequiredSchema<T extends z.ZodTypeAny>(
-  schema: T,
-  conditionalField?: string,
-  expectedValue?: string,
-  errorMessage?: string
-) {
-  return schema.optional().refine(
-    (value) => {
-      const isConditionalFieldSet = conditionalField === expectedValue;
-
-      return !isConditionalFieldSet || !!value;
-    },
-    {
-      message: errorMessage,
-    }
-  );
-}


### PR DESCRIPTION
#### Refactor of Conditional Require Logic for Environment Variables
This PR refactors the logic used to conditionally require environment variables based on other settings. Previously, we used a function called `conditionalRequiredSchema`, which was exclusively invoked by `requiredStorageConfigSchema`. The logic was convoluted and difficult to follow. This refactor simplifies the logic and makes it more intuitive.

#### Changes:
- Replaced conditionalRequiredSchema with a more direct approach using superRefine in Zod schemas.
- Introduced a new utility function requireIfEnvEnabled, which checks if an environment variable is enabled (process.env[<env_name>] === "true") and enforces that another field is required based on this.
- Updated the schema for several environment variables like SWARM_STORAGE_ENABLED and GOOGLE_STORAGE_ENABLED to use this new approach for conditional validation.
