### PR TITLE
refactor(syncers): refactor syncers

### DIFF
--- a/apps/rest-api-server/src/syncers.ts
+++ b/apps/rest-api-server/src/syncers.ts
@@ -19,28 +19,28 @@ export function setUpSyncers() {
 
     if (SWARM_BATCH_ID === undefined) {
       logger.error(`Can't initialize Swarm stamp job: no batch ID provided`);
-      return;
     }
 
     if (BEE_ENDPOINT === undefined) {
       logger.error(
         "Can't initialize Swarm stamp job: no Bee endpoint provided"
       );
-      return;
     }
 
-    const swarmStampSyncer = new BaseSyncer({
-      name: "swarm-stamp",
-      connection,
-      cronPattern: env.SWARM_STAMP_CRON_PATTERN,
-      syncerFn: () =>
-        syncSwarmStamp({
-          beeEndpoint: BEE_ENDPOINT,
-          batchId: SWARM_BATCH_ID,
-        }),
-    });
+    if (SWARM_BATCH_ID !== undefined && BEE_ENDPOINT !== undefined) {
+      const swarmStampSyncer = new BaseSyncer({
+        name: "swarm-stamp",
+        connection,
+        cronPattern: env.SWARM_STAMP_CRON_PATTERN,
+        syncerFn: () =>
+          syncSwarmStamp({
+            beeEndpoint: BEE_ENDPOINT,
+            batchId: SWARM_BATCH_ID,
+          }),
+      });
 
-    syncers.push(swarmStampSyncer);
+      syncers.push(swarmStampSyncer);
+    }
   }
 
   syncers.push(

--- a/packages/syncers/src/index.ts
+++ b/packages/syncers/src/index.ts
@@ -1,3 +1,6 @@
 export { BaseSyncer } from "./BaseSyncer";
-export * from "./syncers";
 export { createRedisConnection } from "./utils";
+
+export { syncSwarmStamp } from "./syncers/SwarmStampSyncer";
+export { aggregateDailyStats } from "./syncers/DailyStatsSyncer";
+export { aggregateOverallStats } from "./syncers/OverallStatsSyncer";

--- a/packages/syncers/src/syncers/DailyStatsSyncer.ts
+++ b/packages/syncers/src/syncers/DailyStatsSyncer.ts
@@ -1,66 +1,49 @@
 import { normalizeDate, toDailyDate } from "@blobscan/dayjs";
 import { prisma } from "@blobscan/db";
+import { createModuleLogger } from "@blobscan/logger";
 
-import { BaseSyncer } from "../BaseSyncer";
-import type { CommonSyncerConfig } from "../BaseSyncer";
 import { formatDate } from "../utils";
 
-export type DailyStatsSyncerConfig = CommonSyncerConfig;
+const logger = createModuleLogger("daily-stats-syncer");
 
-export class DailyStatsSyncer extends BaseSyncer {
-  constructor({ redisUriOrConnection, cronPattern }: DailyStatsSyncerConfig) {
-    const name = "daily-stats";
+export async function aggregateDailyStats() {
+  const lastIndexedBlock = await prisma.block.findLatest();
 
-    super({
-      name,
-      redisUriOrConnection,
-      cronPattern,
-      syncerFn: async () => {
-        const lastIndexedBlock = await prisma.block.findLatest();
-
-        if (!lastIndexedBlock) {
-          this.logger.debug(
-            "Skipping stats aggregation. No blocks indexed yet"
-          );
-
-          return;
-        }
-        const targetDate = normalizeDate(lastIndexedBlock.timestamp).subtract(
-          1,
-          "day"
-        );
-        const targetDay = toDailyDate(targetDate);
-
-        const rawLastDailyStatsDay = await prisma.dailyStats.findFirst({
-          select: { day: true },
-          where: { category: null, rollup: null },
-          orderBy: { day: "desc" },
-        });
-        const lastDailyStatsDay = rawLastDailyStatsDay?.day
-          ? normalizeDate(rawLastDailyStatsDay.day)
-          : undefined;
-
-        if (
-          lastDailyStatsDay
-            ? lastDailyStatsDay?.isSame(targetDay, "day")
-            : false
-        ) {
-          this.logger.debug(`Skipping stats aggregation. Already up to date`);
-
-          return;
-        }
-
-        const res = await prisma.dailyStats.aggregate({
-          from: lastDailyStatsDay?.add(1, "day"),
-          to: targetDay,
-        });
-
-        this.logger.info(
-          `Daily data up to day ${formatDate(
-            targetDay
-          )} aggregated. ${res} daily stats created successfully.`
-        );
-      },
-    });
+  if (!lastIndexedBlock) {
+    logger.debug("Skipping stats aggregation. No blocks indexed yet");
+    return;
   }
+
+  const targetDate = normalizeDate(lastIndexedBlock.timestamp).subtract(
+    1,
+    "day"
+  );
+
+  const targetDay = toDailyDate(targetDate);
+
+  const rawLastDailyStatsDay = await prisma.dailyStats.findFirst({
+    select: { day: true },
+    where: { category: null, rollup: null },
+    orderBy: { day: "desc" },
+  });
+
+  const lastDailyStatsDay = rawLastDailyStatsDay?.day
+    ? normalizeDate(rawLastDailyStatsDay.day)
+    : undefined;
+
+  if (lastDailyStatsDay ? lastDailyStatsDay?.isSame(targetDay, "day") : false) {
+    logger.debug(`Skipping stats aggregation. Already up to date`);
+    return;
+  }
+
+  const res = await prisma.dailyStats.aggregate({
+    from: lastDailyStatsDay?.add(1, "day"),
+    to: targetDay,
+  });
+
+  logger.info(
+    `Daily data up to day ${formatDate(
+      targetDay
+    )} aggregated. ${res} daily stats created successfully.`
+  );
 }

--- a/packages/syncers/src/syncers/OverallStatsSyncer.ts
+++ b/packages/syncers/src/syncers/OverallStatsSyncer.ts
@@ -1,13 +1,11 @@
 import { prisma } from "@blobscan/db";
 import type { BlockNumberRange } from "@blobscan/db";
+import { createModuleLogger } from "@blobscan/logger";
 
-import { BaseSyncer } from "../BaseSyncer";
-import type { CommonSyncerConfig } from "../BaseSyncer";
-
-export interface OverallStatsSyncerConfig extends CommonSyncerConfig {
+type OverallStatsSyncerConfig = {
   batchSize?: number;
   lowestSlot?: number;
-}
+};
 
 const DEFAULT_BATCH_SIZE = 2_000_000;
 const DEFAULT_INITIAL_SLOT = 0;
@@ -16,91 +14,81 @@ function isUnset<T>(value: T | undefined | null): value is null | undefined {
   return value === undefined || value === null;
 }
 
-export class OverallStatsSyncer extends BaseSyncer {
-  constructor({
-    cronPattern,
-    redisUriOrConnection,
-    batchSize = DEFAULT_BATCH_SIZE,
-    lowestSlot = DEFAULT_INITIAL_SLOT,
-  }: OverallStatsSyncerConfig) {
-    const name = "overall-stats";
-    super({
-      name,
-      cronPattern,
-      redisUriOrConnection,
-      syncerFn: async () => {
-        const [blockchainSyncState, latestBlock] = await Promise.all([
-          prisma.blockchainSyncState.findUnique({
-            select: {
-              lastLowerSyncedSlot: true,
-              lastAggregatedBlock: true,
-              lastFinalizedBlock: true,
-            },
-            where: {
-              id: 1,
-            },
-          }),
-          prisma.block.findLatest(),
-        ]);
-        const { lastAggregatedBlock, lastFinalizedBlock, lastLowerSyncedSlot } =
-          blockchainSyncState ?? {};
-        const lastIndexedBlockNumber = latestBlock?.number;
+const logger = createModuleLogger("overall-stats-syncer");
 
-        if (
-          isUnset(lastIndexedBlockNumber) ||
-          isUnset(lastFinalizedBlock) ||
-          lastLowerSyncedSlot !== lowestSlot
-        ) {
-          this.logger.debug(
-            "Skipping stats aggregation. Chain hasn't been fully indexed yet"
-          );
-
-          return;
-        }
-
-        const blockRange: BlockNumberRange = {
-          from: lastAggregatedBlock ? lastAggregatedBlock + 1 : 0,
-          to: Math.min(lastFinalizedBlock, lastIndexedBlockNumber),
-        };
-
-        if (blockRange.from >= blockRange.to) {
-          this.logger.debug(
-            `Skipping stats aggregation. No new finalized blocks (last aggregated block: ${lastAggregatedBlock})`
-          );
-
-          return;
-        }
-
-        const { from, to } = blockRange;
-        const unprocessedBlocks = to - from + 1;
-        const batches = Math.ceil(unprocessedBlocks / batchSize);
-
-        for (let i = 0; i < batches; i++) {
-          const batchFrom = from + i * batchSize;
-          const batchTo = Math.min(batchFrom + batchSize - 1, to);
-          const batchBlockRange: BlockNumberRange = {
-            from: batchFrom,
-            to: batchTo,
-          };
-
-          await prisma.overallStats.aggregate({ blockRange: batchBlockRange });
-
-          if (batches > 1) {
-            const formattedFromBlock = batchBlockRange.from.toLocaleString();
-            const formattedToBlock = batchBlockRange.to.toLocaleString();
-
-            this.logger.debug(
-              `(batch ${
-                i + 1
-              }/${batches}) Data from block ${formattedFromBlock} up to ${formattedToBlock} aggregated successfully`
-            );
-          }
-        }
-
-        this.logger.info(
-          `Data from block ${blockRange.from.toLocaleString()} up to ${blockRange.to.toLocaleString()} aggregated successfully.`
-        );
+export async function aggregateOverallStats({
+  batchSize = DEFAULT_BATCH_SIZE,
+  lowestSlot = DEFAULT_INITIAL_SLOT,
+}: OverallStatsSyncerConfig) {
+  const [blockchainSyncState, latestBlock] = await Promise.all([
+    prisma.blockchainSyncState.findUnique({
+      select: {
+        lastLowerSyncedSlot: true,
+        lastAggregatedBlock: true,
+        lastFinalizedBlock: true,
       },
-    });
+      where: {
+        id: 1,
+      },
+    }),
+    prisma.block.findLatest(),
+  ]);
+  const { lastAggregatedBlock, lastFinalizedBlock, lastLowerSyncedSlot } =
+    blockchainSyncState ?? {};
+  const lastIndexedBlockNumber = latestBlock?.number;
+
+  if (
+    isUnset(lastIndexedBlockNumber) ||
+    isUnset(lastFinalizedBlock) ||
+    lastLowerSyncedSlot !== lowestSlot
+  ) {
+    logger.debug(
+      "Skipping stats aggregation. Chain hasn't been fully indexed yet"
+    );
+
+    return;
   }
+
+  const blockRange: BlockNumberRange = {
+    from: lastAggregatedBlock ? lastAggregatedBlock + 1 : 0,
+    to: Math.min(lastFinalizedBlock, lastIndexedBlockNumber),
+  };
+
+  if (blockRange.from >= blockRange.to) {
+    logger.debug(
+      `Skipping stats aggregation. No new finalized blocks (last aggregated block: ${lastAggregatedBlock})`
+    );
+
+    return;
+  }
+
+  const { from, to } = blockRange;
+  const unprocessedBlocks = to - from + 1;
+  const batches = Math.ceil(unprocessedBlocks / batchSize);
+
+  for (let i = 0; i < batches; i++) {
+    const batchFrom = from + i * batchSize;
+    const batchTo = Math.min(batchFrom + batchSize - 1, to);
+    const batchBlockRange: BlockNumberRange = {
+      from: batchFrom,
+      to: batchTo,
+    };
+
+    await prisma.overallStats.aggregate({ blockRange: batchBlockRange });
+
+    if (batches > 1) {
+      const formattedFromBlock = batchBlockRange.from.toLocaleString();
+      const formattedToBlock = batchBlockRange.to.toLocaleString();
+
+      logger.debug(
+        `(batch ${
+          i + 1
+        }/${batches}) Data from block ${formattedFromBlock} up to ${formattedToBlock} aggregated successfully`
+      );
+    }
+  }
+
+  logger.info(
+    `Data from block ${blockRange.from.toLocaleString()} up to ${blockRange.to.toLocaleString()} aggregated successfully.`
+  );
 }

--- a/packages/syncers/src/syncers/index.ts
+++ b/packages/syncers/src/syncers/index.ts
@@ -1,6 +1,0 @@
-export { DailyStatsSyncer } from "./DailyStatsSyncer";
-export type { DailyStatsSyncerConfig } from "./DailyStatsSyncer";
-export { OverallStatsSyncer } from "./OverallStatsSyncer";
-export type { OverallStatsSyncerConfig } from "./OverallStatsSyncer";
-export { SwarmStampSyncer } from "./SwarmStampSyncer";
-export type { SwarmStampSyncerConfig } from "./SwarmStampSyncer";

--- a/packages/syncers/test/BaseSyncer.test.ts
+++ b/packages/syncers/test/BaseSyncer.test.ts
@@ -14,7 +14,9 @@ describe("BaseSyncer", () => {
       name: "test-updater",
       connection: createRedisConnection("redis://localhost:6379/1"),
       cronPattern: "* * * * *",
-      syncerFn: async () => {},
+      syncerFn: async () => {
+        return;
+      },
     });
 
     return async () => syncer.close();

--- a/packages/syncers/test/DailyStatsSyncer.test.ts
+++ b/packages/syncers/test/DailyStatsSyncer.test.ts
@@ -11,13 +11,13 @@ import {
 } from "./DailyStatsSyncer.test.utils";
 
 describe("DailyStatsSyncer", () => {
-  // it("should aggregate data for all available days", async () => {
-  //   await aggregateDailyStats();
+  it("should aggregate data for all available days", async () => {
+    await aggregateDailyStats();
 
-  //   const dailyStatsDates = await getDailyStatsDates();
+    const dailyStatsDates = await getDailyStatsDates();
 
-  //   expect(dailyStatsDates).toMatchSnapshot();
-  // });
+    expect(dailyStatsDates).toMatchSnapshot();
+  });
 
   it("should skip aggregation if not all blocks have been indexed for the last day", async () => {
     await indexNewBlock(CURRENT_DAY_DATA);

--- a/packages/syncers/test/__snapshots__/BaseSyncer.test.ts.snap
+++ b/packages/syncers/test/__snapshots__/BaseSyncer.test.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PeriodicUpdater > should throw a valid error when failing to close it 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error ocurred when performing closing operation"`;
+exports[`PeriodicUpdater > should throw a valid error when failing to close it 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error occurred when performing closing operation"`;
 
 exports[`PeriodicUpdater > should throw a valid error when failing to close it 2`] = `[Error: Queue closing error]`;
 
-exports[`PeriodicUpdater > when running an updater > should throw a valid error when failing to run 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error ocurred when starting syncer"`;
+exports[`PeriodicUpdater > when running an updater > should throw a valid error when failing to run 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error occurred when starting syncer"`;
 
 exports[`PeriodicUpdater > when running an updater > should throw a valid error when failing to run 2`] = `[Error: Queue error]`;

--- a/packages/syncers/test/__snapshots__/BaseSyncer.test.ts.snap
+++ b/packages/syncers/test/__snapshots__/BaseSyncer.test.ts.snap
@@ -1,5 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`BaseSyncer > should throw a valid error when failing to close it 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error occurred when performing closing operation"`;
+
+exports[`BaseSyncer > should throw a valid error when failing to close it 2`] = `[Error: Queue closing error]`;
+
+exports[`BaseSyncer > when running an updater > should throw a valid error when failing to run 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error occurred when starting syncer"`;
+
+exports[`BaseSyncer > when running an updater > should throw a valid error when failing to run 2`] = `[Error: Queue error]`;
+
 exports[`PeriodicUpdater > should throw a valid error when failing to close it 1`] = `"Syncer \\"test-updater-syncer\\" failed: An error occurred when performing closing operation"`;
 
 exports[`PeriodicUpdater > should throw a valid error when failing to close it 2`] = `[Error: Queue closing error]`;

--- a/packages/syncers/test/__snapshots__/PeriodicUpdater.test.ts.snap
+++ b/packages/syncers/test/__snapshots__/PeriodicUpdater.test.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PeriodicUpdater > should throw a valid error when failing to close it 1`] = `"Updater \\"test-updater-updater\\" failed: An error ocurred when performing closing operation"`;
+exports[`PeriodicUpdater > should throw a valid error when failing to close it 1`] = `"Updater \\"test-updater-updater\\" failed: An error occurred when performing closing operation"`;
 
 exports[`PeriodicUpdater > should throw a valid error when failing to close it 2`] = `[Error: Queue closing error]`;
 
-exports[`PeriodicUpdater > when running an updater > should throw a valid error when failing to run 1`] = `"Updater \\"test-updater-updater\\" failed: An error ocurred when starting updater"`;
+exports[`PeriodicUpdater > when running an updater > should throw a valid error when failing to run 1`] = `"Updater \\"test-updater-updater\\" failed: An error occurred when starting updater"`;
 
 exports[`PeriodicUpdater > when running an updater > should throw a valid error when failing to run 2`] = `[Error: Queue error]`;


### PR DESCRIPTION
### Refactor synchronizers:
This PR removes unnecessary inheritance from the synchronizers. Instead of creating multiple synchronizer classes through inheritance, we now use a single base synchronizer class.

Previously, each subclass was only providing a different synchronize function via the constructor, without adding any new methods or behavior. Since the base synchronizer class already takes a name, a cron pattern, and a synchronize function (which runs according to the cron pattern), the subclasses were redundant. This refactor simplifies the code by directly using the base class.

Additionally, this PR fixes a typo: "ocurred" → "occurred".