### PR TITLE
fix(api): resolve `getByBlockId` and `getBySlot` procedure `trpc-openapi` issues

### DIFF
--- a/packages/api/src/routers/block/getByBlockId.ts
+++ b/packages/api/src/routers/block/getByBlockId.ts
@@ -20,7 +20,23 @@ const blockHashSchema = hashSchema.refine((value) => value.length === 66, {
 
 const blockNumberSchema = z.coerce.number().int().positive();
 
-const blockIdSchema = z.union([blockHashSchema, blockNumberSchema]);
+const blockIdSchema = z.string().transform((value, ctx) => {
+  const parsedHash = blockHashSchema.safeParse(value);
+  const parsedBlockNumber = blockNumberSchema.safeParse(value);
+
+  if (parsedHash.success) {
+    return parsedHash.data;
+  }
+
+  if (parsedBlockNumber.success) {
+    return parsedBlockNumber.data;
+  }
+
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: "Block id must be a valid block number or block hash",
+  });
+});
 
 const inputSchema = z
   .object({

--- a/packages/api/src/routers/block/getByBlockId.ts
+++ b/packages/api/src/routers/block/getByBlockId.ts
@@ -20,6 +20,8 @@ const blockHashSchema = hashSchema.refine((value) => value.length === 66, {
 
 const blockNumberSchema = z.coerce.number().int().positive();
 
+// We use zod's string schema and then parse the value by applying block hash or block number
+// schemas as `trpc-opeanpi` doesn't support union types yet.
 const blockIdSchema = z.string().transform((value, ctx) => {
   const parsedHash = blockHashSchema.safeParse(value);
   const parsedBlockNumber = blockNumberSchema.safeParse(value);

--- a/packages/api/src/routers/block/getBySlot.ts
+++ b/packages/api/src/routers/block/getBySlot.ts
@@ -12,7 +12,7 @@ import {
 } from "../../middlewares/withFilters";
 import { publicProcedure } from "../../procedures";
 import type { BlockIdField } from "./common";
-import { fetchBlock, serializeBlock } from "./common";
+import { fetchBlock, serializeBlock, serializedBlockSchema } from "./common";
 
 const inputSchema = z
   .object({
@@ -20,6 +20,8 @@ const inputSchema = z
   })
   .merge(withSortFilterSchema)
   .merge(createExpandsSchema(["transaction", "blob", "blob_data"]));
+
+const outputSchema = serializedBlockSchema;
 
 export const getBySlot = publicProcedure
   .meta({
@@ -31,6 +33,7 @@ export const getBySlot = publicProcedure
     },
   })
   .input(inputSchema)
+  .output(outputSchema)
   .use(withExpands)
   .use(withFilters)
   .query(


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It fixes `getByBlockId` procedure invalid schema issue and add missing output schema to `getBySlot` procedure.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
