### PR TITLE
Fix spelling errors in API snapshots and retry command test cases

### DIFF
--- a/clis/blob-propagation-jobs-cli/test/commands/retry.test.ts
+++ b/clis/blob-propagation-jobs-cli/test/commands/retry.test.ts
@@ -18,9 +18,9 @@ import {
 describe("Retry command", () => {
   let storageWorkers: BlobPropagationWorker[];
   const jobVersionedHashes = [
-    "versionesHash1",
-    "versionesHash2",
-    "versionesHash3",
+    "versionsHash1",
+    "versionsHash2",
+    "versionsHash3",
   ];
 
   beforeEach(async () => {

--- a/packages/api/test/__snapshots__/blob.test.ts.snap
+++ b/packages/api/test/__snapshots__/blob.test.ts.snap
@@ -2023,7 +2023,7 @@ exports[`Blob router > getAll > when getting filtered blob results > should retu
 ]
 `;
 
-exports[`Blob router > getAll > when getting filtered blob results > should return the results starting from the block specificed 1`] = `
+exports[`Blob router > getAll > when getting filtered blob results > should return the results starting from the block specified 1`] = `
 [
   {
     "blockHash": "blockHash008",

--- a/packages/api/test/__snapshots__/block.test.ts.snap
+++ b/packages/api/test/__snapshots__/block.test.ts.snap
@@ -1232,7 +1232,7 @@ exports[`Block router > getAll > when getting filtered block results > should re
 ]
 `;
 
-exports[`Block router > getAll > when getting filtered block results > should return the results starting from the block specificed 1`] = `
+exports[`Block router > getAll > when getting filtered block results > should return the results starting from the block specified 1`] = `
 [
   {
     "blobAsCalldataGasUsed": "255000",

--- a/packages/api/test/__snapshots__/tx.test.ts.snap
+++ b/packages/api/test/__snapshots__/tx.test.ts.snap
@@ -1799,7 +1799,7 @@ exports[`Transaction router > getAll > when getting filtered transaction results
 ]
 `;
 
-exports[`Transaction router > getAll > when getting filtered transaction results > should return the results starting from the block specificed 1`] = `
+exports[`Transaction router > getAll > when getting filtered transaction results > should return the results starting from the block specified 1`] = `
 [
   {
     "blobAsCalldataGasFee": "10000",

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -172,7 +172,7 @@ export function runFiltersTestsSuite(
       expect(result).toMatchSnapshot();
     });
 
-    it("should return the results starting from the block specificed", async () => {
+    it("should return the results starting from the block specified", async () => {
       const result = await fetcher({
         startBlock: 1007,
       });


### PR DESCRIPTION
- **Fixed spelling in `retry.test.ts`**:
  - `versionesHash1`, `versionesHash2`, `versionesHash3` → `versionsHash1`, `versionsHash2`, `versionsHash3` in job versioned hashes.

- **Updated API snapshot test files (`blob.test.ts.snap`, `block.test.ts.snap`, `tx.test.ts.snap`)**:
  - Corrected `"specificed"` → `"specified"` in multiple test cases to ensure proper terminology.

- **Fixed spelling in `helpers.ts`**:
  - `"specificed"` → `"specified"` in block filter test descriptions.
