### PR TITLE
fix: documentation link and typo

### DIFF
--- a/apps/docs/src/app/docs/testing/page.md
+++ b/apps/docs/src/app/docs/testing/page.md
@@ -23,7 +23,7 @@ We rely on testing to ensure our solutions meet user expectations.
 
 **Framework:** We utilize [Vitest](https://vitest.dev), which is set up with a [workspace configuration](https://vitest.dev/guide/workspace.html) tailored for our monorepo.
 
-**Integration Testing:** Our integration tests run with a local PostgreSQL database and a [fake GCS server](https://github.com/fsouza/fake-gcs-server), orchestrated via [Docker](https://www.docker.com). This ensures our tests mimic real-world scenarios. We employ a [specific script](https://github.com/Blobscan/blobscan/blob/next/scripts/run-integration.sh) to set up these services before initiating tests.
+**Integration Testing:** Our integration tests run with a local PostgreSQL database and a [fake GCS server](https://github.com/fsouza/fake-gcs-server), orchestrated via [Docker](https://www.docker.com). This ensures our tests mimic real-world scenarios. We employ a [specific script](https://github.com/Blobscan/blobscan/blob/main/scripts/run-integration.sh) to set up these services before initiating tests.
 
 ## Setting Up Your Environment
 

--- a/packages/api/test/indexer.test.ts
+++ b/packages/api/test/indexer.test.ts
@@ -698,7 +698,7 @@ describe("Indexer router", async () => {
           expect(dbRewindedBlockTxs).toEqual(dbRewindedBlockForkTxs);
         });
 
-        describe("when cleaing up block references", () => {
+        describe("when cleaning up block references", () => {
           let rewindedBlockNumbers: number[];
           beforeAll(async () => {
             rewindedBlockNumbers = await authorizedContext.prisma.block


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.  
- [ ] I have added tests to cover my changes.  
- [ ] I have filled out the description and linked the related issues.  

### Description  
Fixed a broken link in the documentation and corrected a typo in the test file.  

### Motivation and Context  
- **`page.md`** – Updated an outdated script link.  
- **`indexer.test.ts`** – Fixed a typo in a test description (`cleaing` → `cleaning`).  

### Related Issue  
N/A  

### Screenshots (if appropriate):  
N/A  