### PR TITLE
chore: make `GOOGLE_STORAGE_API_ENDPOINT` optional

### DIFF
--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -103,10 +103,7 @@ export const env = createEnv({
       // Google Cloud Storage
       GOOGLE_STORAGE_ENABLED: booleanSchema.default("false"),
       GOOGLE_STORAGE_PROJECT_ID: z.string().optional(),
-      GOOGLE_STORAGE_API_ENDPOINT: z
-        .string()
-        .optional()
-        .superRefine(requireIfEnvEnabled("GOOGLE_STORAGE_ENABLED")),
+      GOOGLE_STORAGE_API_ENDPOINT: z.string().optional(),
       GOOGLE_STORAGE_BUCKET_NAME: z
         .string()
         .optional()


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It makes `GOOGLE_STORAGE_API_ENDPOINT` optional again, as it’s used only for development.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
