### PR TITLE
fix(api): remove sort query param

### DIFF
--- a/.changeset/mighty-flies-occur.md
+++ b/.changeset/mighty-flies-occur.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Removed `sort` query param from `getBySlot` procedure

--- a/packages/api/src/routers/block/getBySlot.ts
+++ b/packages/api/src/routers/block/getBySlot.ts
@@ -6,10 +6,7 @@ import {
   createExpandsSchema,
   withExpands,
 } from "../../middlewares/withExpands";
-import {
-  withFilters,
-  withSortFilterSchema,
-} from "../../middlewares/withFilters";
+import { withFilters } from "../../middlewares/withFilters";
 import { publicProcedure } from "../../procedures";
 import type { BlockIdField } from "./common";
 import { fetchBlock, serializeBlock, serializedBlockSchema } from "./common";
@@ -18,7 +15,6 @@ const inputSchema = z
   .object({
     slot: z.coerce.number().int().positive(),
   })
-  .merge(withSortFilterSchema)
   .merge(createExpandsSchema(["transaction", "blob", "blob_data"]));
 
 const outputSchema = serializedBlockSchema;


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It removes `sort` query param from `getBySlot` procedure

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
