### PR TITLE
Fix `SwarmNodeError` cause handling  

### DIFF
--- a/packages/syncers/src/errors.ts
+++ b/packages/syncers/src/errors.ts
@@ -42,7 +42,7 @@ export class SwarmNodeError extends ErrorException {
       message = error.message;
     }
 
-    super(message, error.cause);
+    super(message, { cause: error.cause });
 
     this.code = code;
     this.reasons = reasons;


### PR DESCRIPTION
Fixed incorrect `cause` handling in `SwarmNodeError` constructor:
   - Replaced `super(message, error.cause);` with `super(message, { cause: error.cause });`  
