### PR TITLE
fix(rest-api-server): increase request body size limit

### DIFF
--- a/.changeset/silver-sloths-kick.md
+++ b/.changeset/silver-sloths-kick.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/rest-api-server": patch
+---
+
+Increased maximum request body size allowed

--- a/apps/rest-api-server/src/index.ts
+++ b/apps/rest-api-server/src/index.ts
@@ -32,7 +32,7 @@ const closeSyncers = setUpSyncers();
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.json({ limit: "4mb" }));
+app.use(bodyParser.json({ limit: "3mb" }));
 app.use(morganMiddleware);
 
 app.get("/metrics", metricsHandler);

--- a/apps/rest-api-server/src/index.ts
+++ b/apps/rest-api-server/src/index.ts
@@ -32,7 +32,7 @@ const closeSyncers = setUpSyncers();
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.json({ limit: "2mb" }));
+app.use(bodyParser.json({ limit: "4mb" }));
 app.use(morganMiddleware);
 
 app.get("/metrics", metricsHandler);

--- a/apps/rest-api-server/src/morgan.ts
+++ b/apps/rest-api-server/src/morgan.ts
@@ -7,6 +7,6 @@ const stream = {
 };
 
 export const morganMiddleware = morgan(
-  ":remote-addr :method :url :status :res[content-length] - :response-time ms",
+  ":remote-addr :method :url :status :req[Content-Length] bytes - :response-time ms",
   { stream }
 );


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It increases maximum allowed request body size to 3mb

#### Motivation and Context (Optional)
Following the recent Pectra upgrade, indexing request body sizes have increased significantly, as up to nine blobs can now be indexed (~2.36mb).

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
