### PR TITLE
refactor(api): breakdown procedure input schema into smaller input schemas

### DIFF
--- a/packages/api/src/routers/blob/getAll.ts
+++ b/packages/api/src/routers/blob/getAll.ts
@@ -22,10 +22,6 @@ import {
 } from "./common/serializers";
 import { countBlobs } from "./getCount";
 
-const inputSchema = withPaginationSchema
-  .merge(withAllFiltersSchema)
-  .merge(createExpandsSchema(["transaction", "block"]));
-
 const outputSchema = z.object({
   blobs: serializedBlobOnTransactionSchema.array(),
   totalBlobs: z.number().optional(),
@@ -40,9 +36,11 @@ export const getAll = publicProcedure
       summary: "retrieves all blobs.",
     },
   })
-  .input(inputSchema)
+  .input(withPaginationSchema)
   .use(withPagination)
+  .input(withAllFiltersSchema)
   .use(withFilters)
+  .input(createExpandsSchema(["transaction", "block"]))
   .use(withExpands)
   .output(outputSchema)
   .query(async ({ ctx: { filters, expands, pagination, prisma, count } }) => {

--- a/packages/api/src/routers/block/getAll.ts
+++ b/packages/api/src/routers/block/getAll.ts
@@ -22,11 +22,6 @@ import {
 } from "./common";
 import { countBlocks } from "./getCount";
 
-const inputSchema = withAllFiltersSchema
-  .merge(createExpandsSchema(["transaction", "blob"]))
-  .merge(withPaginationSchema)
-  .optional();
-
 const outputSchema = z.object({
   blocks: serializedBlockSchema.array(),
   totalBlocks: z.number().optional(),
@@ -41,9 +36,11 @@ export const getAll = publicProcedure
       summary: "retrieves all blocks.",
     },
   })
-  .input(inputSchema)
+  .input(withAllFiltersSchema)
   .use(withFilters)
+  .input(createExpandsSchema(["transaction", "blob"]))
   .use(withExpands)
+  .input(withPaginationSchema)
   .use(withPagination)
   .output(outputSchema)
   .query(async ({ ctx: { expands, filters, pagination, prisma, count } }) => {

--- a/packages/api/src/routers/tx/getAll.ts
+++ b/packages/api/src/routers/tx/getAll.ts
@@ -23,11 +23,6 @@ import {
 } from "./common";
 import { countTxs } from "./getCount";
 
-const inputSchema = withAllFiltersSchema
-  .merge(createExpandsSchema(["block", "blob"]))
-  .merge(withPaginationSchema)
-  .optional();
-
 const outputSchema = z.object({
   transactions: serializedTransactionSchema.array(),
   totalTransactions: z.number().optional(),
@@ -42,9 +37,11 @@ export const getAll = publicProcedure
       summary: "retrieves all blob transactions.",
     },
   })
-  .input(inputSchema)
+  .input(withAllFiltersSchema)
   .use(withFilters)
+  .input(createExpandsSchema(["block", "blob"]))
   .use(withExpands)
+  .input(withPaginationSchema)
   .use(withPagination)
   .output(outputSchema)
   .query(async ({ ctx: { prisma, expands, filters, pagination, count } }) => {


### PR DESCRIPTION
…finitions

### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Break down the TRPC procedure input schemas into smaller input definitions to prevent excessively deep type instantiation TS error.
#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
