### PR TITLE
feat(metrics): add Prometheus metrics for latest block and slot

### DIFF
--- a/packages/api/src/instrumentation.ts
+++ b/packages/api/src/instrumentation.ts
@@ -54,6 +54,11 @@ export const latestSlotGauge = registerGauge(
   "Latest slot indexed by Blobscan"
 );
 
+export const lastBlockIndexTimestampGauge = registerGauge(
+  "blobscan_last_block_index_timestamp",
+  "Timestamp of the last block indexed by Blobscan"
+);
+
 export async function metricsHandler(
   _: NodeHTTPRequest,
   res: NodeHTTPResponse
@@ -71,6 +76,7 @@ export async function metricsHandler(
       if (latestBlock) {
         latestBlockNumberGauge.set(latestBlock.number);
         latestSlotGauge.set(latestBlock.slot);
+        lastBlockIndexTimestampGauge.set(Math.floor(Date.now() / 1000));
       }
     } catch (error) {
       console.error("Failed to update latest block metrics:", error);

--- a/packages/api/src/instrumentation.ts
+++ b/packages/api/src/instrumentation.ts
@@ -66,7 +66,6 @@ export async function metricsHandler(
       return;
     }
 
-    // Update the latest block and slot metrics
     try {
       const latestBlock = await prisma.block.findLatest();
       if (latestBlock) {


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Add three new Prometheus metrics to expose indexing progress:
- blobscan_latest_block_number: Tracks the latest block number indexed
- blobscan_latest_slot: Tracks the latest slot indexed
- blobscan_last_block_index_timestamp: Timestamp of the last block indexed by Blobscan

#### Motivation and Context (Optional)

These metrics help monitor the indexing status of Blobscan and can be used for alerting on indexing delays or gaps.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
