### PR TITLE
Fix broken Indexer link in API documentation

### DIFF
--- a/apps/docs/src/app/docs/api/page.md
+++ b/apps/docs/src/app/docs/api/page.md
@@ -8,7 +8,7 @@ nextjs:
 
 Blobscan provides `api.blobscan.com`, a REST API that you can use to retrieve blobs, blocks and transactions metrics and use them in your own dashboards.
 
-This API provides also some endpoints that are used internally by the [Indexer](indexer). For security, these endpoints
+This API provides also some endpoints that are used internally by the [Indexer](../indexer). For security, these endpoints
 are protected with a shared secret that is used for digitally signing JSON Web Tokens (JWT).
 This is what the `SECRET_KEY` environment variable is for.
 


### PR DESCRIPTION
Corrected the relative link to the Indexer documentation in apps/docs/src/app/docs/api/page.md to ensure proper navigation and resolve the "Cannot find file" error. The link now correctly points to the ../indexer directory.