### PR TITLE
fix(metrics): blobscan_last_block_index_timestamp was incorrect

### DIFF
--- a/packages/api/src/instrumentation.ts
+++ b/packages/api/src/instrumentation.ts
@@ -76,7 +76,9 @@ export async function metricsHandler(
       if (latestBlock) {
         latestBlockNumberGauge.set(latestBlock.number);
         latestSlotGauge.set(latestBlock.slot);
-        lastBlockIndexTimestampGauge.set(Math.floor(Date.now() / 1000));
+        lastBlockIndexTimestampGauge.set(
+          Math.floor(latestBlock.insertedAt.getTime() / 1000)
+        );
       }
     } catch (error) {
       console.error("Failed to update latest block metrics:", error);


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
