### PR TITLE
docs(api): fix path to indexer

### DIFF
--- a/apps/docs/src/app/docs/api/page.md
+++ b/apps/docs/src/app/docs/api/page.md
@@ -8,7 +8,7 @@ nextjs:
 
 Blobscan provides `api.blobscan.com`, a REST API that you can use to retrieve blobs, blocks and transactions metrics and use them in your own dashboards.
 
-This API provides also some endpoints that are used internally by the [Indexer](indexer). For security, these endpoints
+This API provides also some endpoints that are used internally by the [Indexer](../indexer). For security, these endpoints
 are protected with a shared secret that is used for digitally signing JSON Web Tokens (JWT).
 This is what the `SECRET_KEY` environment variable is for.
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

Corrected the relative link to the Indexer documentation in apps/docs/src/app/docs/api/page.md to ensure proper navigation and resolve the "Cannot find file" error. The link now correctly points to the ../indexer directory.

### Screenshots (if appropriate):
The problem is:
![image](https://github.com/user-attachments/assets/34662387-326c-4add-988a-9047180f75c5)

and after the changes:
![image](https://github.com/user-attachments/assets/80b97441-3756-4594-8df2-8ec486230468)


