### PR TITLE
feat(api): add blob data storage references field to block and transaction API responses

### DIFF
--- a/.changeset/quiet-geckos-study.md
+++ b/.changeset/quiet-geckos-study.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": minor
+---
+
+Added blob storage references field to block and transaction API responses by default

--- a/packages/api/src/middlewares/withExpands.ts
+++ b/packages/api/src/middlewares/withExpands.ts
@@ -28,15 +28,6 @@ export const expandedBlobSelect = {
   commitment: true,
   proof: true,
   size: true,
-  dataStorageReferences: {
-    select: {
-      blobStorage: true,
-      dataReference: true,
-    },
-    orderBy: {
-      blobStorage: "asc",
-    },
-  },
 } satisfies Prisma.BlobSelect;
 
 const expandedBlockSelect = {
@@ -66,9 +57,7 @@ export type ExpandedTransaction = Prisma.TransactionGetPayload<{
 
 export type ExpandedBlob = Prisma.BlobGetPayload<{
   select: typeof expandedBlobSelect;
-}> & {
-  data?: string;
-};
+}>;
 
 export type ExpandedBlobWithData = ExpandedBlob & { data?: string };
 

--- a/packages/api/src/routers/blob/helpers.ts
+++ b/packages/api/src/routers/blob/helpers.ts
@@ -21,16 +21,18 @@ import {
   prismaBlobOnTransactionSchema,
 } from "../../zod-schemas";
 
+const dataStorageReferenceSelect = {
+  blobStorage: true,
+  dataReference: true,
+} satisfies Prisma.BlobDataStorageReferenceSelect;
+5;
 export const baseBlobSelect = {
   commitment: true,
   proof: true,
   size: true,
   versionedHash: true,
   dataStorageReferences: {
-    select: {
-      blobStorage: true,
-      dataReference: true,
-    } satisfies Prisma.BlobDataStorageReferenceSelect,
+    select: dataStorageReferenceSelect,
     orderBy: {
       blobStorage: "asc",
     },
@@ -55,6 +57,10 @@ type PrismaBlobOnTransaction = Prisma.BlobsOnTransactionsGetPayload<{
   select: typeof baseBlobOnTransactionSelect;
 }>;
 
+type DataStorageReference = Prisma.BlobDataStorageReferenceGetPayload<{
+  select: typeof dataStorageReferenceSelect;
+}>;
+
 export type CompletePrismaBlob = Prettify<
   PrismaBlob & {
     transactions: Prettify<
@@ -70,7 +76,9 @@ export type CompletePrismaBlob = Prettify<
 
 export type CompletePrismaBlobOnTransaction = Prettify<
   PrismaBlobOnTransaction & {
-    blob: ExpandedBlob;
+    blob: {
+      dataStorageReferences: DataStorageReference[];
+    } & ExpandedBlob;
     block?: ExpandedBlock;
     transaction?: ExpandedTransaction & {
       block: { blobGasPrice: ExpandedBlock["blobGasPrice"] };

--- a/packages/api/src/utils/transformers.ts
+++ b/packages/api/src/utils/transformers.ts
@@ -66,17 +66,23 @@ export function normalizePrismaTransactionFields({
   };
 }
 
+export function normalizeDataStorageReferences(
+  dataStorageReferences: PrismaBlob["dataStorageReferences"]
+) {
+  return dataStorageReferences.map(({ blobStorage, dataReference }) => ({
+    storage: blobStorage,
+    url: buildBlobDataUrl(blobStorage, dataReference),
+  }));
+}
+
 export function normalizePrismaBlobFields({
   dataStorageReferences,
   ...restBlob
 }: PrismaBlob) {
   return {
     ...restBlob,
-    dataStorageReferences: dataStorageReferences.map(
-      ({ blobStorage, dataReference }) => ({
-        storage: blobStorage,
-        url: buildBlobDataUrl(blobStorage, dataReference),
-      })
+    dataStorageReferences: normalizeDataStorageReferences(
+      dataStorageReferences
     ),
   };
 }

--- a/packages/api/src/zod-schemas.ts
+++ b/packages/api/src/zod-schemas.ts
@@ -79,7 +79,6 @@ export const prismaBlobSchema = BlobModel.omit({
   insertedAt: true,
   updatedAt: true,
 }).extend({
-  data: z.string().optional(),
   dataStorageReferences: z.array(
     BlobDataStorageReferenceModel.pick({
       blobStorage: true,

--- a/packages/api/test/__snapshots__/block.test.ts.snap
+++ b/packages/api/test/__snapshots__/block.test.ts.snap
@@ -235,6 +235,7 @@ exports[`Block router > getAll > when getting expanded block results > should re
         "blobGasUsed": 131072n,
         "blobs": [
           {
+            "dataStorageReferences": [],
             "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
           },
         ],
@@ -268,12 +269,42 @@ exports[`Block router > getAll > when getting expanded block results > should re
         "blobGasUsed": 393216n,
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -306,12 +337,30 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
           },
         ],
@@ -332,12 +381,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -346,6 +421,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -354,9 +439,25 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -382,6 +483,7 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [],
             "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
           },
         ],
@@ -402,12 +504,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -428,6 +560,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368/data",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash006",
+              },
+            ],
             "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
           },
         ],
@@ -453,12 +595,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -467,6 +635,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -475,9 +653,25 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -498,12 +692,30 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
           },
         ],
@@ -524,12 +736,34 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -538,12 +772,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -569,12 +833,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -595,12 +889,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -621,6 +945,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -641,9 +975,25 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -669,6 +1019,12 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436/data",
+              },
+            ],
             "versionedHash": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436",
           },
         ],
@@ -694,6 +1050,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368/data",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash006",
+              },
+            ],
             "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
           },
         ],
@@ -714,12 +1080,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -728,6 +1124,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -748,6 +1154,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -756,6 +1172,12 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -764,6 +1186,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -772,6 +1204,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -780,6 +1222,12 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash005/data",
+              },
+            ],
             "versionedHash": "blobHash005",
           },
         ],
@@ -805,6 +1253,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -813,6 +1271,12 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -821,6 +1285,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -829,6 +1303,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -837,6 +1321,12 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash005/data",
+              },
+            ],
             "versionedHash": "blobHash005",
           },
         ],
@@ -857,12 +1347,34 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -871,12 +1383,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -902,6 +1444,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -922,12 +1474,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -953,12 +1531,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -984,12 +1588,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -1015,12 +1645,30 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+              },
+            ],
             "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
           },
         ],
@@ -1041,12 +1689,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -1055,6 +1729,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -1063,9 +1747,25 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -1091,12 +1791,38 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -1105,6 +1831,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -1113,9 +1849,25 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -1141,6 +1893,7 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [],
             "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
           },
         ],
@@ -1161,12 +1914,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -1192,6 +1975,7 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [],
             "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
           },
         ],
@@ -1212,12 +1996,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -1238,6 +2052,16 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368/data",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash006",
+              },
+            ],
             "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
           },
         ],
@@ -1263,6 +2087,7 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [],
             "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
           },
         ],
@@ -1283,12 +2108,42 @@ exports[`Block router > getAll > when getting filtered block results > should re
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -1314,6 +2169,7 @@ exports[`Block router > getAll > when getting paginated block results > should d
       {
         "blobs": [
           {
+            "dataStorageReferences": [],
             "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
           },
         ],
@@ -1334,12 +2190,42 @@ exports[`Block router > getAll > when getting paginated block results > should d
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+              },
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash004/data",
+              },
+            ],
             "versionedHash": "blobHash004",
           },
         ],
@@ -1365,6 +2251,16 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -1373,6 +2269,12 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
         ],
@@ -1381,6 +2283,16 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -1389,6 +2301,16 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+              },
+            ],
             "versionedHash": "blobHash003",
           },
         ],
@@ -1397,6 +2319,12 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "postgres",
+                "url": "http://localhost:3001/blobs/blobHash005/data",
+              },
+            ],
             "versionedHash": "blobHash005",
           },
         ],
@@ -1417,12 +2345,34 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+              },
+            ],
             "versionedHash": "blobHash002",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -1431,12 +2381,42 @@ exports[`Block router > getAll > when getting paginated block results > should r
       {
         "blobs": [
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
           {
+            "dataStorageReferences": [
+              {
+                "storage": "google",
+                "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+              },
+              {
+                "storage": "swarm",
+                "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+              },
+            ],
             "versionedHash": "blobHash001",
           },
         ],
@@ -1463,12 +2443,30 @@ exports[`Block router > getByBlockId > should get a block by block number 1`] = 
     {
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+            },
+          ],
           "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+            },
+          ],
           "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+            },
+          ],
           "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
         },
       ],
@@ -1492,6 +2490,12 @@ exports[`Block router > getByBlockId > should get a block by hash 1`] = `
     {
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436/data",
+            },
+          ],
           "versionedHash": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436",
         },
       ],
@@ -1515,6 +2519,12 @@ exports[`Block router > getByBlockId > should get a reorged block by block numbe
     {
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436/data",
+            },
+          ],
           "versionedHash": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436",
         },
       ],
@@ -1538,6 +2548,7 @@ exports[`Block router > getByBlockId > should get the canonical block when provi
     {
       "blobs": [
         {
+          "dataStorageReferences": [],
           "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
         },
       ],
@@ -1692,12 +2703,30 @@ exports[`Block router > getByBlockId > when getting expanded block results > sho
       "blobGasUsed": 393216n,
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+            },
+          ],
           "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+            },
+          ],
           "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "postgres",
+              "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+            },
+          ],
           "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
         },
       ],
@@ -1762,12 +2791,38 @@ exports[`Block router > getBySlot > should get a block by slot 1`] = `
     {
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+            },
+          ],
           "versionedHash": "blobHash001",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+            },
+          ],
           "versionedHash": "blobHash002",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+            },
+          ],
           "versionedHash": "blobHash003",
         },
       ],
@@ -1776,6 +2831,16 @@ exports[`Block router > getBySlot > should get a block by slot 1`] = `
     {
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+            },
+          ],
           "versionedHash": "blobHash001",
         },
       ],
@@ -1784,9 +2849,25 @@ exports[`Block router > getBySlot > should get a block by slot 1`] = `
     {
       "blobs": [
         {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+            },
+          ],
           "versionedHash": "blobHash001",
         },
         {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+            },
+          ],
           "versionedHash": "blobHash002",
         },
       ],

--- a/packages/api/test/__snapshots__/tx.test.ts.snap
+++ b/packages/api/test/__snapshots__/tx.test.ts.snap
@@ -119,6 +119,7 @@ exports[`Transaction router > getAll > when getting expanded transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [],
         "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
       },
     ],
@@ -150,12 +151,42 @@ exports[`Transaction router > getAll > when getting expanded transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -308,12 +339,30 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+          },
+        ],
         "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+          },
+        ],
         "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+          },
+        ],
         "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
       },
     ],
@@ -341,9 +390,25 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 262144n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -371,6 +436,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -398,12 +473,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -436,6 +537,7 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [],
         "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
       },
     ],
@@ -463,12 +565,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -496,6 +628,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368/data",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash006",
+          },
+        ],
         "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
       },
     ],
@@ -528,12 +670,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -561,6 +729,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -588,9 +766,25 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 262144n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -623,12 +817,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -656,12 +880,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -689,6 +943,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -716,9 +980,25 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 262144n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -751,6 +1031,12 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 262144n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436/data",
+          },
+        ],
         "versionedHash": "0x01d5cc28986f58db309e0fae63b60ade81a01667721e190ec142051240b5d436",
       },
     ],
@@ -783,6 +1069,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368/data",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash006",
+          },
+        ],
         "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
       },
     ],
@@ -810,6 +1106,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -837,12 +1143,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -870,6 +1206,12 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash005/data",
+          },
+        ],
         "versionedHash": "blobHash005",
       },
     ],
@@ -897,6 +1239,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -924,6 +1276,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -951,6 +1313,12 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -978,6 +1346,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1010,6 +1388,12 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash005/data",
+          },
+        ],
         "versionedHash": "blobHash005",
       },
     ],
@@ -1037,6 +1421,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1064,6 +1458,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1091,6 +1495,12 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -1118,6 +1528,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1145,12 +1565,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1178,12 +1628,34 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1216,6 +1688,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1243,12 +1725,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1281,12 +1789,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1319,12 +1853,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1357,12 +1917,30 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b1/data",
+          },
+        ],
         "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b1",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b2/data",
+          },
+        ],
         "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b2",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x000000000000000000000000000000000000000000000000000000000000b3/data",
+          },
+        ],
         "versionedHash": "0x000000000000000000000000000000000000000000000000000000000000b3",
       },
     ],
@@ -1390,9 +1968,25 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 262144n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -1420,6 +2014,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1447,12 +2051,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1485,9 +2115,25 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 262144n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
     ],
@@ -1515,6 +2161,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1542,12 +2198,38 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+          },
+        ],
         "versionedHash": "blobHash002",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+          },
+        ],
         "versionedHash": "blobHash003",
       },
     ],
@@ -1580,6 +2262,7 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [],
         "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
       },
     ],
@@ -1607,12 +2290,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -1645,6 +2358,7 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [],
         "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
       },
     ],
@@ -1672,12 +2386,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -1705,6 +2449,16 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368/data",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash006",
+          },
+        ],
         "versionedHash": "0x010001c79d78a76fb9b4bab3896ee3ea32f3e2607da7801eb1a92da39d6c1368",
       },
     ],
@@ -1737,6 +2491,7 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [],
         "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
       },
     ],
@@ -1764,12 +2519,42 @@ exports[`Transaction router > getAll > when getting filtered transaction results
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -1802,6 +2587,7 @@ exports[`Transaction router > getAll > when getting paginated transaction result
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [],
         "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
       },
     ],
@@ -1829,12 +2615,42 @@ exports[`Transaction router > getAll > when getting paginated transaction result
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash004.txt",
+          },
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash004/data",
+          },
+        ],
         "versionedHash": "blobHash004",
       },
     ],
@@ -1867,12 +2683,42 @@ exports[`Transaction router > getAll > when getting paginated transaction result
     "blobGasUsed": 393216n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
       {
+        "dataStorageReferences": [
+          {
+            "storage": "google",
+            "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+          },
+          {
+            "storage": "swarm",
+            "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+          },
+        ],
         "versionedHash": "blobHash001",
       },
     ],
@@ -1900,6 +2746,12 @@ exports[`Transaction router > getAll > when getting paginated transaction result
     "blobGasUsed": 131072n,
     "blobs": [
       {
+        "dataStorageReferences": [
+          {
+            "storage": "postgres",
+            "url": "http://localhost:3001/blobs/blobHash005/data",
+          },
+        ],
         "versionedHash": "blobHash005",
       },
     ],
@@ -1935,12 +2787,38 @@ exports[`Transaction router > getByHash > should get a transaction by hash corre
   "blobGasUsed": 393216n,
   "blobs": [
     {
+      "dataStorageReferences": [
+        {
+          "storage": "google",
+          "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+        },
+        {
+          "storage": "swarm",
+          "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+        },
+      ],
       "versionedHash": "blobHash001",
     },
     {
+      "dataStorageReferences": [
+        {
+          "storage": "google",
+          "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+        },
+      ],
       "versionedHash": "blobHash002",
     },
     {
+      "dataStorageReferences": [
+        {
+          "storage": "google",
+          "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+        },
+        {
+          "storage": "swarm",
+          "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+        },
+      ],
       "versionedHash": "blobHash003",
     },
   ],
@@ -2042,12 +2920,38 @@ exports[`Transaction router > getByHash > when getting expanded transaction resu
   "blobGasUsed": 393216n,
   "blobs": [
     {
+      "dataStorageReferences": [
+        {
+          "storage": "google",
+          "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash001.txt",
+        },
+        {
+          "storage": "swarm",
+          "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash001",
+        },
+      ],
       "versionedHash": "blobHash001",
     },
     {
+      "dataStorageReferences": [
+        {
+          "storage": "google",
+          "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash002.txt",
+        },
+      ],
       "versionedHash": "blobHash002",
     },
     {
+      "dataStorageReferences": [
+        {
+          "storage": "google",
+          "url": "https://storage.googleapis.com/blobscan-test-bucket/1/ob/Ha/sh/obHash003.txt",
+        },
+        {
+          "storage": "swarm",
+          "url": "https://gateway.ethswarm.org/access/bzz://some-hash-for-blobHash003",
+        },
+      ],
       "versionedHash": "blobHash003",
     },
   ],


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It adds `dataStorageReferences` field to block and transaction responses

#### Motivation and Context (Optional)

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
