### PR TITLE
Remove trailing asterisk from GitHub URL in PriceFeed.ts

### DIFF
--- a/packages/price-feed/src/PriceFeed.ts
+++ b/packages/price-feed/src/PriceFeed.ts
@@ -199,7 +199,7 @@ export class PriceFeed {
    * Finds the round data that corresponds to a timestamp using binary search algorithm
    *
    * *This function is an adaptation of this implementation:
-   * https://github.com/smartcontractkit/quickstarts-historical-prices-api/blob/main/lib/binarySearch.ts*
+   * https://github.com/smartcontractkit/quickstarts-historical-prices-api/blob/main/lib/binarySearch.ts
    *
    * @param aggregator The phase aggregator contract to search in.
    * @param targetTimestamp The target timestamp.


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
Fixed the broken link in packages/price-feed/src/PriceFeed.ts by removing the trailing asterisk that was causing a 404 error. The URL to the binary search implementation should not have this extra character.


### Screenshots (if appropriate):
<img width="646" alt="image" src="https://github.com/user-attachments/assets/de4519b9-e44b-4502-8222-287e7c5ee3f6" />
