### PR TITLE
fix: make swarm syncer work after SWARM_BATCH_ID change

### DIFF
--- a/packages/syncers/src/syncers/SwarmStampSyncer.ts
+++ b/packages/syncers/src/syncers/SwarmStampSyncer.ts
@@ -58,17 +58,19 @@ export class SwarmStampSyncer extends BaseSyncer {
             swarmDataTTL: batchTTL,
           },
           update: {
+            swarmDataId: batchId,
             swarmDataTTL: batchTTL,
             updatedAt: new Date(),
           },
           where: {
             id: 1,
-            swarmDataId: batchId,
           },
         });
 
         const expiryDate = formatTtl(batchTTL);
-        this.logger.info(`Swarm batch ID "${batchId}" updated. New expiry date: ${expiryDate}.`);
+        this.logger.info(
+          `Swarm batch ID "${batchId}" updated. New expiry date: ${expiryDate}.`
+        );
       },
     });
   }


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

This is a bug found in staging, after changing SWARM_BATCH_ID. The where clause causes a new row is added with an incremental id, instead of replacing the currently existing.

<!--Please include a summary of the change and which issue is fixed.-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
