### PR TITLE
fix: run SwarmStampSyncer when a batch id has been previously configured

### DIFF
--- a/apps/rest-api-server/src/syncers.ts
+++ b/apps/rest-api-server/src/syncers.ts
@@ -2,6 +2,7 @@ import type { PublicClient } from "viem";
 import { createPublicClient, http } from "viem";
 import * as chains from "viem/chains";
 
+import { prisma } from "@blobscan/db";
 import { env } from "@blobscan/env";
 import { PriceFeed } from "@blobscan/price-feed";
 import type { BaseSyncer } from "@blobscan/syncers";
@@ -20,23 +21,22 @@ export async function setUpSyncers() {
   const connection = createRedisConnection(env.REDIS_URI);
   const syncers: BaseSyncer[] = [];
 
-  if (env.SWARM_STORAGE_ENABLED) {
-    if (!env.SWARM_BATCH_ID) {
-      logger.error(`Can't initialize Swarm stamp job: no batch ID provided`);
-    } else if (!env.BEE_ENDPOINT) {
-      logger.error(
-        "Can't initialize Swarm stamp job: no Bee endpoint provided"
-      );
-    } else {
-      syncers.push(
-        new SwarmStampSyncer({
-          cronPattern: env.SWARM_STAMP_CRON_PATTERN,
-          redisUriOrConnection: connection,
-          batchId: env.SWARM_BATCH_ID,
-          beeEndpoint: env.BEE_ENDPOINT,
-        })
-      );
-    }
+  // SwarmStampSyncer is added if there is already an element with id 1
+  // This is useful in case Swarm storage is temporarily disabled, so that
+  // the Swarm TTL is still updated.
+  const blobStoragesState = await prisma.blobStoragesState.findUnique({
+    where: { id: 1 },
+  });
+  if (blobStoragesState) {
+    logger.info("SwarmStampSyncer added");
+    syncers.push(
+      new SwarmStampSyncer({
+        cronPattern: env.SWARM_STAMP_CRON_PATTERN,
+        redisUriOrConnection: connection,
+        batchId: env.SWARM_BATCH_ID,
+        beeEndpoint: env.BEE_ENDPOINT,
+      })
+    );
   }
 
   syncers.push(

--- a/apps/rest-api-server/src/syncers.ts
+++ b/apps/rest-api-server/src/syncers.ts
@@ -33,8 +33,8 @@ export async function setUpSyncers() {
       new SwarmStampSyncer({
         cronPattern: env.SWARM_STAMP_CRON_PATTERN,
         redisUriOrConnection: connection,
-        batchId: env.SWARM_BATCH_ID,
-        beeEndpoint: env.BEE_ENDPOINT,
+        batchId: env.SWARM_BATCH_ID || blobStoragesState.swarmDataId,
+        beeEndpoint: env.BEE_ENDPOINT || "http://localhost:1633",
       })
     );
   }


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
The Swarm TTL is not updated if SWARM_STORAGE_ENABLED=false, e.g. when Swarm storage is temporarily disabled.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
