### PR TITLE
fix(web): display full daily stats on homepage

### DIFF
--- a/.changeset/eleven-days-peel.md
+++ b/.changeset/eleven-days-peel.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Improved daily stats sampling fetching performance

--- a/.changeset/fuzzy-points-pull.md
+++ b/.changeset/fuzzy-points-pull.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Returned full amount of daily stats when the number of requested stats is limited


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
This PR updates the homepage to display full daily stats for the 3-month charts.
It also improves the performance of stats fetching on the stats page by optimizing the sampling logic.
#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
