### PR TITLE
fix(web): make overall stats horizontal scrollbar always visible

### DIFF
--- a/.changeset/lucky-toes-add.md
+++ b/.changeset/lucky-toes-add.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Made overall stats scrollbar always visible

--- a/apps/web/src/components/DeltaPercentage.tsx
+++ b/apps/web/src/components/DeltaPercentage.tsx
@@ -11,8 +11,6 @@ export const DeltaPercentageChange = function <T extends number | bigint>({
   initialValue,
   finalValue,
 }: DeltaPercentageChangeProps<T>) {
-  console.log("Rendering");
-
   const sign =
     finalValue < initialValue ? "-" : finalValue > initialValue ? "+" : "";
   const delta = finalValue - initialValue;

--- a/apps/web/src/components/Scrollable.tsx
+++ b/apps/web/src/components/Scrollable.tsx
@@ -1,14 +1,19 @@
 import { useRef } from "react";
 import type { FC, ReactNode } from "react";
 import { useScroll, a, to } from "@react-spring/web";
+import classNames from "classnames";
 
 import { useOverflow } from "~/hooks/useOverflow";
 
 type ScrollableProps = {
   children: ReactNode;
+  displayScrollbar?: boolean;
 };
 
-export const Scrollable: FC<ScrollableProps> = function ({ children }) {
+export const Scrollable: FC<ScrollableProps> = function ({
+  children,
+  displayScrollbar = false,
+}) {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const containerRef = useRef<HTMLDivElement>(null!);
   const { scrollYProgress, scrollXProgress } = useScroll({
@@ -19,11 +24,15 @@ export const Scrollable: FC<ScrollableProps> = function ({ children }) {
   return (
     <a.div
       ref={containerRef}
+      className={classNames({
+        "pb-1 pr-1 transition-colors dark:[&::-webkit-scrollbar-corner]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-primary-800 dark:hover:[&::-webkit-scrollbar-thumb]:bg-accentHighlight-dark/60 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-gray-100 dark:[&::-webkit-scrollbar-track]:bg-surface-dark/60 [&::-webkit-scrollbar]:max-h-1.5 [&::-webkit-scrollbar]:max-w-1.5":
+          displayScrollbar,
+        "[&::-webkit-scrollbar]:hidden": !displayScrollbar,
+      })}
       style={{
         width: "100%",
-        scrollbarWidth: "none",
-        msOverflowStyle: "none",
-        overflow: "scroll",
+        overflowX: xOverflowing ? "scroll" : "hidden",
+        overflowY: yOverflowing ? "scroll" : "hidden",
         maskImage: to([scrollXProgress, scrollYProgress], (x, y) => {
           const gradients = [];
 

--- a/apps/web/src/pages/stats.tsx
+++ b/apps/web/src/pages/stats.tsx
@@ -376,8 +376,8 @@ const Stats: NextPage = function () {
         </div>
       </Card>
       <div className="flex flex-col gap-4">
-        <OverallMetricWrapper>
-          <div className="flex flex-row gap-4">
+        <OverallMetricWrapper displayScrollbar>
+          <div className="flex w-full flex-row gap-4">
             {splitArrayIntoChunks(
               displayedSections.flatMap((s) => s.metrics),
               2


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/a752c936-3ed2-4dc5-a769-bf9c7020fd5f" />

