### PR TITLE
Update codecov/codecov-action@v4 to codecov/codecov-action@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           VITEST_MAINNET_FORK_URL: ${{ secrets.VITEST_MAINNET_FORK_URL }}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Blobscan/blobscan


### PR DESCRIPTION
 - codecov/codecov-action@v4
 + codecov/codecov-action@v5

Latest version confirmation: https://github.com/codecov/codecov-action/releases/tag/v5.4.3