### PR TITLE
feat(web): add Octant Epoch 8 banner

### DIFF
--- a/.changeset/eleven-otters-end.md
+++ b/.changeset/eleven-otters-end.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Added Octant Epoch 8 banner

--- a/apps/web/src/components/AppLayout/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout/AppLayout.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import cn from "classnames";
 
 import { useIsHomepage } from "~/hooks/useIsHomePage";
+import { OctantBanner } from "../OctantBanner";
 import { BottomBarLayout } from "./BottomBarLayout";
 import { TopBarLayout } from "./TopBarLayout";
 
@@ -11,9 +13,15 @@ interface LayoutProps {
 
 const AppLayout = ({ children }: LayoutProps) => {
   const isHomepage = useIsHomepage();
+  const [bannerOpened, setBannerOpened] = useState(true);
 
   return (
     <div className="flex min-h-screen flex-col">
+      {bannerOpened && (
+        <OctantBanner
+          onClose={() => setBannerOpened((prevOpened) => !prevOpened)}
+        />
+      )}
       <TopBarLayout />
       <main
         className={cn("container mx-auto grow", {

--- a/apps/web/src/components/OctantBanner.tsx
+++ b/apps/web/src/components/OctantBanner.tsx
@@ -1,0 +1,83 @@
+import type { FC } from "react";
+import { XMarkIcon } from "@heroicons/react/20/solid";
+
+import dayjs from "@blobscan/dayjs";
+
+import { Link } from "./Link";
+
+type OctantBannerProps = {
+  onClose(): void;
+};
+
+const EPOCH_START_DATE = "2025-07-11T23:59:00";
+
+export const OctantBanner: FC<OctantBannerProps> = function GitcoinBanner({
+  onClose,
+}) {
+  return (
+    <div className="relative isolate flex items-center gap-x-6 overflow-hidden bg-primary-100 px-6 py-2.5 dark:bg-slate-300 sm:px-3.5 sm:before:flex-1">
+      <div
+        className="absolute left-[max(-7rem,calc(50%-52rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
+        aria-hidden="true"
+      >
+        <div
+          className="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-primary-200 to-primary-600 opacity-30"
+          style={{
+            clipPath:
+              "polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)",
+          }}
+        />
+      </div>
+      <div
+        className="absolute left-[max(45rem,calc(50%+8rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
+        aria-hidden="true"
+      >
+        <div
+          className="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-primary-200 to-primary-600 opacity-30"
+          style={{
+            clipPath:
+              "polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)",
+          }}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <p className="text-sm leading-6 text-gray-900">
+          <strong className="font-semibold">
+            We&#39;re participating on the Octant Epoch 8 Round! 🎉
+          </strong>
+          <svg
+            viewBox="0 0 2 2"
+            className="mx-2 inline h-0.5 w-0.5 fill-current"
+            aria-hidden="true"
+          >
+            <circle cx={1} cy={1} r={1} />
+          </svg>
+          Support us by getting and locking{" "}
+          <Link isExternal href="https://octant.build/en-EN/glm-token">
+            GLM
+          </Link>
+          , then allocating it to us during the next allocation window starting{" "}
+          <span className="font-bold">
+            {dayjs(EPOCH_START_DATE).fromNow()}.
+          </span>
+        </p>
+        <a
+          href="https://octant.app/home"
+          className="flex-none rounded-full bg-gray-900 px-3.5 py-1 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
+        >
+          Go to Octant Epoch 8
+        </a>
+      </div>
+      <div className="flex flex-1 justify-end">
+        <button
+          type="button"
+          className="-m-3 p-3 focus-visible:outline-offset-[-4px]"
+          onClick={() => onClose()}
+        >
+          <span className="sr-only">Dismiss</span>
+          <XMarkIcon className="h-5 w-5 text-gray-900" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/OctantBanner.tsx
+++ b/apps/web/src/components/OctantBanner.tsx
@@ -52,11 +52,11 @@ export const OctantBanner: FC<OctantBannerProps> = function GitcoinBanner({
           >
             <circle cx={1} cy={1} r={1} />
           </svg>
-          Support us by getting and locking{" "}
+          Support us by locking{" "}
           <Link isExternal href="https://octant.build/en-EN/glm-token">
             GLM
           </Link>
-          , then allocating it to us during the next allocation window starting{" "}
+          , then donating during the next allocation window, starting{" "}
           <span className="font-bold">
             {dayjs(EPOCH_START_DATE).fromNow()}.
           </span>


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It adds a banner at the top of the page announcing the upcoming Octant Epoch 8 round.


#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
It resolves #812 
### Screenshots (if appropriate):

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/1ba40ed3-e36b-45ab-838f-acd023236c4c" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4f381617-ab22-4db0-a385-5b99e2945197" />

