### PR TITLE
feat(api): dynamically change logging level via API

### DIFF
--- a/apps/docs/src/app/docs/environment/page.md
+++ b/apps/docs/src/app/docs/environment/page.md
@@ -33,6 +33,7 @@ nextjs:
 
 | Variable                                               | Description                                                                                        | Required                        | Default value                                |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------- |
+| `ADMIN_API_KEY`                                       | API key used to authenticate requests to admin endpoints (e.g., logging level management)         | No                              | (empty)                                      |
 | `BLOB_DATA_API_ENABLED`                                | Controls whether the blob data API endpoint is enabled                                             | No                              | `true`                                       |
 | `BLOB_DATA_API_KEY`                                    | API key used to authenticate requests to retrieve blob data from the blobscan API                  | No                              | (empty)                                      |
 | `CHAIN_ID`                                             | EVM chain id                                                                                       | Yes                             | `1`                                          |

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -7,6 +7,7 @@ import { blockRouter } from "./routers/block";
 import { blockchainSyncStateRouter } from "./routers/blockchain-sync-state";
 import { ethPriceRouter } from "./routers/eth-price";
 import { indexerRouter } from "./routers/indexer";
+import { loggingRouter } from "./routers/logging";
 import { searchRouter } from "./routers/search";
 import { stateRouter } from "./routers/state";
 import { statsRouter } from "./routers/stats";
@@ -24,6 +25,7 @@ export const appRouter = t.router({
   syncState: blockchainSyncStateRouter,
   blobStoragesState: blobStoragesStateRouter,
   ethPrice: ethPriceRouter,
+  logging: loggingRouter,
   healthcheck: publicProcedure
     .meta({
       openapi: {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,6 +15,7 @@ export { gracefulShutdown } from "./graceful-shutdown";
 export { metricsHandler } from "./instrumentation";
 
 export { searchByTerm } from "./routers/search/byTerm";
+export { loggingRouter } from "./routers/logging";
 
 /**
  * Inference helpers for input types

--- a/packages/api/src/routers/logging.ts
+++ b/packages/api/src/routers/logging.ts
@@ -1,0 +1,70 @@
+import type { LoggerLevel } from "@blobscan/logger";
+import { getLogLevel, setLogLevel } from "@blobscan/logger";
+import { z } from "@blobscan/zod";
+
+import { createAuthedProcedure } from "../procedures";
+import { t } from "../trpc-client";
+
+// Define the valid log levels as a Zod enum
+const LogLevelEnum = z.enum(["error", "warn", "info", "http", "debug"]);
+const adminProcedure = createAuthedProcedure("admin");
+
+export const loggingRouter = t.router({
+  getLevel: adminProcedure
+    .meta({
+      openapi: {
+        method: "GET",
+        path: "/logging/level",
+        summary: "Get the current logging level",
+        tags: ["system"],
+      },
+    })
+    .input(z.void())
+    .output(
+      z.object({
+        level: LogLevelEnum,
+        success: z.boolean(),
+      })
+    )
+    .query(() => {
+      const currentLevel = getLogLevel();
+
+      return {
+        level: currentLevel,
+        success: true,
+      };
+    }),
+
+  setLevel: adminProcedure
+    .meta({
+      openapi: {
+        method: "PUT",
+        path: "/logging/level",
+        summary: "Change the logging level",
+        tags: ["system"],
+      },
+    })
+    .input(
+      z.object({
+        level: LogLevelEnum,
+      })
+    )
+    .output(
+      z.object({
+        level: LogLevelEnum,
+        previousLevel: LogLevelEnum,
+        success: z.boolean(),
+      })
+    )
+    .mutation(({ input }) => {
+      const { level } = input;
+      const previousLevel = getLogLevel();
+      const success = setLogLevel(level as LoggerLevel);
+
+      return {
+        level,
+        previousLevel,
+        success,
+      };
+    }),
+});

--- a/packages/api/src/utils/auth.ts
+++ b/packages/api/src/utils/auth.ts
@@ -9,7 +9,7 @@ type NextHTTPRequest = CreateNextContextOptions["req"];
 
 type HTTPRequest = NodeHTTPRequest | NextHTTPRequest;
 
-export type APIClientType = "indexer" | "weavevm" | "blob-data";
+export type APIClientType = "indexer" | "weavevm" | "blob-data" | "admin";
 
 export type APIClient = {
   type: APIClientType;
@@ -27,6 +27,10 @@ function isValidWeaveVMAPIKey(token: string) {
 
 function isValidBlobDataAPIKey(token: string) {
   return token === env.BLOB_DATA_API_KEY;
+}
+
+function isValidAdminAPIKey(token: string) {
+  return token === env.ADMIN_API_KEY;
 }
 
 export function retrieveAPIClient(req: HTTPRequest): APIClient | undefined {
@@ -49,6 +53,10 @@ export function retrieveAPIClient(req: HTTPRequest): APIClient | undefined {
 
     if (isValidWeaveVMAPIKey(token)) {
       return { type: "weavevm" };
+    }
+
+    if (isValidAdminAPIKey(token)) {
+      return { type: "admin" };
     }
 
     if (isValidIndexerAPIKey(token)) {

--- a/packages/api/test/logging.test.ts
+++ b/packages/api/test/logging.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { appRouter } from "../src/app-router";
+import { createTestContext, unauthorizedRPCCallTest } from "./helpers";
+import * as logger from "@blobscan/logger";
+
+// Mock the logger module
+vi.mock("@blobscan/logger", async () => {
+  const actual = await vi.importActual("@blobscan/logger");
+  return {
+    ...actual as object,
+    getLogLevel: vi.fn(),
+    setLogLevel: vi.fn(),
+  };
+});
+
+describe("Logging Router", () => {
+  const mockGetLogLevel = vi.mocked(logger.getLogLevel);
+  const mockSetLogLevel = vi.mocked(logger.setLogLevel);
+  
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockGetLogLevel.mockReset();
+    mockSetLogLevel.mockReset();
+  });
+  
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+  
+  describe("getLevel", () => {
+    it("should return the current log level", async () => {
+      // Arrange
+      const ctx = await createTestContext({
+        apiClient: { type: "admin" },
+      });
+      const caller = appRouter.createCaller(ctx);
+      mockGetLogLevel.mockReturnValue("info");
+      
+      // Act
+      const result = await caller.logging.getLevel();
+      
+      // Assert
+      expect(mockGetLogLevel).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        level: "info",
+        success: true,
+      });
+    });
+    
+    it("should fail when calling procedure without auth", async () => {
+      await unauthorizedRPCCallTest(async () => {
+        const ctx = await createTestContext();
+        const caller = appRouter.createCaller(ctx);
+        return caller.logging.getLevel();
+      });
+    });
+  });
+  
+  describe("setLevel", () => {
+    it("should change the log level successfully", async () => {
+      // Arrange
+      const ctx = await createTestContext({
+        apiClient: { type: "admin" },
+      });
+      const caller = appRouter.createCaller(ctx);
+      mockGetLogLevel.mockReturnValue("info");
+      mockSetLogLevel.mockReturnValue(true);
+      
+      // Act
+      const result = await caller.logging.setLevel({ level: "debug" });
+      
+      // Assert
+      expect(mockGetLogLevel).toHaveBeenCalledTimes(1);
+      expect(mockSetLogLevel).toHaveBeenCalledWith("debug");
+      expect(result).toEqual({
+        level: "debug",
+        previousLevel: "info",
+        success: true,
+      });
+    });
+    
+    it("should handle failure when setting log level", async () => {
+      // Arrange
+      const ctx = await createTestContext({
+        apiClient: { type: "admin" },
+      });
+      const caller = appRouter.createCaller(ctx);
+      mockGetLogLevel.mockReturnValue("info");
+      mockSetLogLevel.mockReturnValue(false);
+      
+      // Act
+      const result = await caller.logging.setLevel({ level: "debug" });
+      
+      // Assert
+      expect(mockGetLogLevel).toHaveBeenCalledTimes(1);
+      expect(mockSetLogLevel).toHaveBeenCalledWith("debug");
+      expect(result).toEqual({
+        level: "debug",
+        previousLevel: "info",
+        success: false,
+      });
+    });
+    
+    it("should fail when calling procedure without auth", async () => {
+      await unauthorizedRPCCallTest(async () => {
+        const ctx = await createTestContext();
+        const caller = appRouter.createCaller(ctx);
+        return caller.logging.setLevel({ level: "debug" });
+      });
+    });
+  });
+});

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -53,6 +53,7 @@ export const env = createEnv({
       SECRET_KEY: z.string(),
       BLOB_DATA_API_ENABLED: booleanSchema.default("true"),
       BLOB_DATA_API_KEY: z.string().optional(),
+      ADMIN_API_KEY: z.string().optional(),
       CHAIN_ID: z.coerce.number().positive().default(1),
       DENCUN_FORK_SLOT: z.coerce.number().optional(),
       NETWORK_NAME: networkSchema.default("mainnet"),


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

- Add ADMIN_API_KEY environment variable for secure access
- Add functionality to modify logging level at runtime
- Implement tRPC endpoints for getting and setting log level
- Enhance logger module to track all logger instances
- Add proper OpenAPI documentation with system tag

#### Motivation and Context (Optional)

No need to restart the container to load the new configuration when LOG_LEVEL is modified.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
