### PR TITLE
fix typo in Error Messages

### DIFF
--- a/packages/syncers/src/BaseSyncer.ts
+++ b/packages/syncers/src/BaseSyncer.ts
@@ -60,7 +60,7 @@ export class BaseSyncer {
     });
 
     this.worker.on("failed", (_, err) => {
-      this.logger.error(new ErrorException("A worker error ocurred", err));
+      this.logger.error(new ErrorException("A worker error occurred", err));
     });
 
     this.connection = connection;
@@ -82,7 +82,7 @@ export class BaseSyncer {
     } catch (err) {
       throw new SyncerError(
         this.name,
-        "An error ocurred when starting syncer",
+        "An error occurred when starting syncer",
         err
       );
     }
@@ -117,7 +117,7 @@ export class BaseSyncer {
     } catch (err) {
       const err_ = new SyncerError(
         this.name,
-        "An error ocurred when performing closing operation",
+        "An error occurred when performing closing operation",
         err
       );
 


### PR DESCRIPTION


**Description:**  
This pull request fixes a typo in the error messages within `BaseSyncer.ts`, changing "occured" to the correct spelling "occurred" for improved clarity and professionalism. 