### PR TITLE
feat(web): display rollup counts on block cards and table

### DIFF
--- a/.changeset/little-frogs-know.md
+++ b/.changeset/little-frogs-know.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Added display of rollup counts on block cards, block table, and rollup badges to indicate multiple instances of the same rollup.

--- a/apps/web/src/components/Badges/RollupBadge.tsx
+++ b/apps/web/src/components/Badges/RollupBadge.tsx
@@ -244,6 +244,7 @@ const ROLLUP_CUSTOM_STYLES: Partial<Record<Rollup, string>> = {
 };
 
 type RollupBadgeProps = BadgeProps & {
+  amount?: number;
   rollup: Rollup;
   compact?: boolean;
 };
@@ -251,16 +252,24 @@ type RollupBadgeProps = BadgeProps & {
 export const RollupBadge: React.FC<RollupBadgeProps> = ({
   compact = false,
   rollup,
+  amount = 1,
   ...props
 }) => {
   const { style, label = capitalize(rollup) } = ROLLUP_CONFIG[rollup];
   const rollupIcon = (
-    <Icon
-      src={ICONS[rollup]}
-      title={label}
-      className={ROLLUP_CUSTOM_STYLES[rollup]}
-      size={props.size ?? "md"}
-    />
+    <div className="relative">
+      <Icon
+        src={ICONS[rollup]}
+        title={label}
+        className={ROLLUP_CUSTOM_STYLES[rollup]}
+        size={props.size ?? "md"}
+      />
+      {amount > 1 && (
+        <div className="absolute -bottom-2 -right-1 text-[10px] text-black dark:text-contentSecondary-dark">
+          {amount}
+        </div>
+      )}
+    </div>
   );
 
   return compact ? (

--- a/apps/web/src/components/Cards/SurfaceCards/BlockCard.tsx
+++ b/apps/web/src/components/Cards/SurfaceCards/BlockCard.tsx
@@ -33,8 +33,20 @@ const BlockCard: FC<Partial<BlockCardProps>> = function ({
     () => transactions?.reduce((acc, tx) => acc + tx.blobs.length, 0),
     [transactions]
   );
-  const rollups =
-    (transactions?.map((tx) => tx.rollup).filter(Boolean) as Rollup[]) ?? [];
+  const rollupToAmount =
+    transactions?.reduce<Partial<Record<Rollup, number>>>(
+      (amounts, { blobs, rollup }) => {
+        if (!rollup) {
+          return amounts;
+        }
+        const amount = amounts[rollup] ?? 0;
+
+        amounts[rollup] = amount + blobs.length;
+
+        return amounts;
+      },
+      {} as Partial<Record<Rollup, number>>
+    ) ?? [];
 
   const hasOneBlob = blobCount === 1;
 
@@ -51,8 +63,13 @@ const BlockCard: FC<Partial<BlockCardProps>> = function ({
           )}
         </div>
         <div className="flex items-center gap-2">
-          {rollups.map((rollup, i) => (
-            <RollupBadge key={i} rollup={rollup} compact />
+          {Object.entries(rollupToAmount).map(([rollup, amount], i) => (
+            <RollupBadge
+              key={i}
+              rollup={rollup as Rollup}
+              amount={amount}
+              compact
+            />
           ))}
         </div>
       </div>

--- a/apps/web/src/pages/blocks.tsx
+++ b/apps/web/src/pages/blocks.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import type { NextPage } from "next";
 
@@ -20,7 +21,7 @@ import { api } from "~/api-client";
 import { useQueryParams } from "~/hooks/useQueryParams";
 import NextError from "~/pages/_error";
 import { useEnv } from "~/providers/Env";
-import type { BlockWithExpandedTransactions } from "~/types";
+import type { BlockWithExpandedTransactions, Rollup } from "~/types";
 import {
   buildBlobRoute,
   buildBlockRoute,
@@ -131,23 +132,34 @@ const Blocks: NextPage = function () {
             dataStorageReferences,
           }))
         );
+        const rollupToAmount = txsBlobs.reduce<Partial<Record<Rollup, number>>>(
+          (amounts, { rollup }) => {
+            if (!rollup) {
+              return amounts;
+            }
+            const amount = amounts[rollup] ?? 0;
+
+            amounts[rollup] = amount + 1;
+
+            return amounts;
+          },
+          {} as Partial<Record<Rollup, number>>
+        );
 
         return {
           cells: [
             {
               item: (
-                <div className="relative flex">
-                  {[...new Set(transactions.map((tx) => tx.rollup))].map(
-                    (rollup, i) => {
-                      return rollup ? (
-                        <div key={i} className="-ml-1 first-of-type:ml-0">
-                          <RollupBadge rollup={rollup} compact />
-                        </div>
-                      ) : (
-                        <></>
-                      );
-                    }
-                  )}
+                <div className="relative flex gap-1">
+                  {Object.entries(rollupToAmount).map(([rollup, amount]) => (
+                    <div key={rollup} className="-ml-0.5">
+                      <RollupBadge
+                        amount={amount}
+                        rollup={rollup as Rollup}
+                        compact
+                      />
+                    </div>
+                  ))}
                 </div>
               ),
             },

--- a/apps/web/src/pages/blocks.tsx
+++ b/apps/web/src/pages/blocks.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import type { NextPage } from "next";
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It adds display of rollup counts on block cards, block table, and rollup badges to indicate multiple instances of the same rollup.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

<img width="307" height="296" alt="image" src="https://github.com/user-attachments/assets/13f0ea7d-c7f3-4331-a392-0b79c26af90c" />

<img width="515" height="390" alt="image" src="https://github.com/user-attachments/assets/79895e5f-8e92-44cd-975b-c92999433911" />

