### PR TITLE
refactor: make date period parsing more explicit in withDatePeriod middleware

### DIFF
--- a/packages/api/src/middlewares/withDate.ts
+++ b/packages/api/src/middlewares/withDate.ts
@@ -17,7 +17,8 @@ export const dateSchema = z.object({
 });
 
 export const withDatePeriod = t.middleware(({ next, input }) => {
-  const { from, to } = datePeriodSchema.parse(input) || {};
+  const parsed = datePeriodSchema.parse(input);
+  const { from, to } = parsed || {};
   const hasAtLeastOneDate = Boolean(from || to);
 
   const datePeriod = hasAtLeastOneDate


### PR DESCRIPTION
Separate datePeriodSchema.parse() and destructuring operations for better readability

- Split the combined parsing and destructuring into two distinct steps
- Makes the code intention clearer and easier to understand
- Improves maintainability by making the fallback logic more explicit
- No functional changes, only code style improvement