### PR TITLE
feat(api): add support for retrieving `latest` and `oldest` blocks

### DIFF
--- a/.changeset/beige-houses-sniff.md
+++ b/.changeset/beige-houses-sniff.md
@@ -1,0 +1,6 @@
+---
+"@blobscan/api": minor
+"@blobscan/db": minor
+---
+
+Added support for retrieving latest and oldest block

--- a/packages/api/src/routers/block/getBySlot.ts
+++ b/packages/api/src/routers/block/getBySlot.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 
+import type { BlockIdField } from "@blobscan/db/prisma/zod-utils";
 import { z } from "@blobscan/zod";
 
 import {
@@ -9,7 +10,6 @@ import {
 import { withFilters } from "../../middlewares/withFilters";
 import { publicProcedure } from "../../procedures";
 import { normalize } from "../../utils";
-import type { BlockIdField } from "./helpers";
 import { responseBlockSchema, fetchBlock, toResponseBlock } from "./helpers";
 
 const inputSchema = z

--- a/packages/api/test/__snapshots__/block.test.ts.snap
+++ b/packages/api/test/__snapshots__/block.test.ts.snap
@@ -2738,6 +2738,138 @@ exports[`Block router > getByBlockId > should get a reorged block by block numbe
 }
 `;
 
+exports[`Block router > getByBlockId > should get latest block 1`] = `
+{
+  "blobAsCalldataGasUsed": 255000n,
+  "blobBaseFee": 121000000n,
+  "blobBaseUsdFee": undefined,
+  "blobGasPrice": 22n,
+  "blobGasUsdPrice": undefined,
+  "blobGasUsed": 5500000n,
+  "ethUsdPrice": undefined,
+  "excessBlobGas": 15000n,
+  "hash": "0x8000000000000000000000000000000000000000000000000000000000000000",
+  "number": 1008,
+  "slot": 108,
+  "timestamp": 2023-08-31T16:00:00.000Z,
+  "transactions": [
+    {
+      "blobs": [
+        {
+          "dataStorageReferences": [],
+          "versionedHash": "0xb100000000000000000000000000000000000000000000000000000000000000",
+        },
+      ],
+      "hash": "txHash016",
+    },
+  ],
+}
+`;
+
+exports[`Block router > getByBlockId > should get oldest block 1`] = `
+{
+  "blobAsCalldataGasUsed": 2042780n,
+  "blobBaseFee": 17301504n,
+  "blobBaseUsdFee": undefined,
+  "blobGasPrice": 22n,
+  "blobGasUsdPrice": undefined,
+  "blobGasUsed": 786432n,
+  "ethUsdPrice": undefined,
+  "excessBlobGas": 15000n,
+  "hash": "0x1000000000000000000000000000000000000000000000000000000000000000",
+  "number": 1001,
+  "slot": 101,
+  "timestamp": 2022-10-16T12:00:00.000Z,
+  "transactions": [
+    {
+      "blobs": [
+        {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "http://localhost:4443/storage/v1/b/blobscan-test-bucket/o/1%2Fob%2FHa%2Fsh%2FobHash001.bin?alt=media",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://api.gateway.ethswarm.org/bzz/bzz://some-hash-for-blobHash001",
+            },
+          ],
+          "versionedHash": "blobHash001",
+        },
+        {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "http://localhost:4443/storage/v1/b/blobscan-test-bucket/o/1%2Fob%2FHa%2Fsh%2FobHash002.bin?alt=media",
+            },
+          ],
+          "versionedHash": "blobHash002",
+        },
+        {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "http://localhost:4443/storage/v1/b/blobscan-test-bucket/o/1%2Fob%2FHa%2Fsh%2FobHash003.bin?alt=media",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://api.gateway.ethswarm.org/bzz/bzz://some-hash-for-blobHash003",
+            },
+          ],
+          "versionedHash": "blobHash003",
+        },
+      ],
+      "hash": "txHash001",
+    },
+    {
+      "blobs": [
+        {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "http://localhost:4443/storage/v1/b/blobscan-test-bucket/o/1%2Fob%2FHa%2Fsh%2FobHash001.bin?alt=media",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://api.gateway.ethswarm.org/bzz/bzz://some-hash-for-blobHash001",
+            },
+          ],
+          "versionedHash": "blobHash001",
+        },
+      ],
+      "hash": "txHash002",
+    },
+    {
+      "blobs": [
+        {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "http://localhost:4443/storage/v1/b/blobscan-test-bucket/o/1%2Fob%2FHa%2Fsh%2FobHash001.bin?alt=media",
+            },
+            {
+              "storage": "swarm",
+              "url": "https://api.gateway.ethswarm.org/bzz/bzz://some-hash-for-blobHash001",
+            },
+          ],
+          "versionedHash": "blobHash001",
+        },
+        {
+          "dataStorageReferences": [
+            {
+              "storage": "google",
+              "url": "http://localhost:4443/storage/v1/b/blobscan-test-bucket/o/1%2Fob%2FHa%2Fsh%2FobHash002.bin?alt=media",
+            },
+          ],
+          "versionedHash": "blobHash002",
+        },
+      ],
+      "hash": "txHash003",
+    },
+  ],
+}
+`;
+
 exports[`Block router > getByBlockId > should get the canonical block when providing a block number matching a reorged block 1`] = `
 {
   "blobAsCalldataGasUsed": 255000n,

--- a/packages/api/test/block.test.ts
+++ b/packages/api/test/block.test.ts
@@ -91,6 +91,22 @@ describe("Block router", async () => {
       expect(result).toMatchSnapshot();
     });
 
+    it("should get latest block", async () => {
+      const result = await blockCaller.getByBlockId({
+        id: "latest",
+      });
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it("should get oldest block", async () => {
+      const result = await blockCaller.getByBlockId({
+        id: "oldest",
+      });
+
+      expect(result).toMatchSnapshot();
+    });
+
     it("should get a reorged block by block number", async () => {
       const result = await blockCaller.getByBlockId({
         id: "1008",

--- a/packages/db/prisma/extensions/base.ts
+++ b/packages/db/prisma/extensions/base.ts
@@ -12,11 +12,11 @@ import { Prisma } from "@prisma/client";
 
 import { curryPrismaExtensionFnSpan } from "../instrumentation";
 import type { WithoutTimestampFields } from "../types";
+import type { BlockId, BlockIdField } from "../zod-utils";
 import {
   blobCommitmentSchema,
   blobVersionedHashSchema,
-  blockHashSchema,
-  blockNumberSchema,
+  parsedBlockIdSchema,
 } from "../zod-utils";
 
 const NOW_SQL = Prisma.sql`NOW()`;
@@ -248,30 +248,57 @@ export const baseExtension = Prisma.defineExtension((prisma) =>
         },
       },
       block: {
-        findEthUsdPrice(blockId: string | number) {
-          let whereClause: Prisma.Sql;
-          const isBlockNumber =
-            !blockId.toString().startsWith("0x") &&
-            blockNumberSchema.safeParse(blockId).success;
-          const isBlockHash = blockHashSchema.safeParse(blockId).success;
+        findEthUsdPrice(blockIdOrBlockIdField: BlockId | BlockIdField) {
+          let blockIdField: BlockIdField;
 
-          if (!isBlockHash && !isBlockNumber) {
-            throw new Error(
-              `Couldn't retrieve ETH/USD price for block: id "${blockId}" is invalid`
-            );
+          console.log(blockIdOrBlockIdField);
+          if (typeof blockIdOrBlockIdField === "object") {
+            blockIdField = blockIdOrBlockIdField;
+          } else {
+            const res = parsedBlockIdSchema.safeParse(blockIdOrBlockIdField);
+
+            if (!res.success) {
+              throw new Error(
+                `Couldn't retrieve ETH/USD price for block: id "${blockIdOrBlockIdField}" is invalid`
+              );
+            }
+
+            blockIdField = res.data;
           }
 
-          if (isBlockHash) {
-            whereClause = Prisma.sql`b.hash = ${blockId}`;
-          } else {
-            whereClause = Prisma.sql`b.number = ${blockId}`;
+          const { type, value } = blockIdField;
+          let whereClause: Prisma.Sql = Prisma.empty;
+          let orderBy: Prisma.Sql = Prisma.empty;
+
+          switch (type) {
+            case "hash": {
+              console.log(value);
+              whereClause = Prisma.sql`WHERE b.hash = ${value}`;
+              break;
+            }
+            case "number": {
+              whereClause = Prisma.sql`WHERE b.number = ${value}`;
+              break;
+            }
+            case "slot": {
+              whereClause = Prisma.sql`WHERE b.slot = ${value}`;
+              break;
+            }
+            case "label": {
+              const direction =
+                value === "latest" ? Prisma.sql`DESC` : Prisma.sql`ASC`;
+
+              orderBy = Prisma.sql`ORDER BY b.number ${direction} LIMIT 1`;
+              break;
+            }
           }
 
           return startBlockModelFnSpan("findEthUsdPrice", async () => {
             const ethUsdPrice = await prisma.$queryRaw<EthUsdPrice[]>`
               SELECT p.id, p.price, p.timestamp
               FROM block b join eth_usd_price p on DATE_TRUNC('minute', b.timestamp) = p.timestamp
-              WHERE ${whereClause}
+              ${whereClause}
+              ${orderBy}
             `;
 
             return ethUsdPrice[0];

--- a/packages/db/prisma/extensions/base.ts
+++ b/packages/db/prisma/extensions/base.ts
@@ -251,7 +251,6 @@ export const baseExtension = Prisma.defineExtension((prisma) =>
         findEthUsdPrice(blockIdOrBlockIdField: BlockId | BlockIdField) {
           let blockIdField: BlockIdField;
 
-          console.log(blockIdOrBlockIdField);
           if (typeof blockIdOrBlockIdField === "object") {
             blockIdField = blockIdOrBlockIdField;
           } else {
@@ -272,7 +271,6 @@ export const baseExtension = Prisma.defineExtension((prisma) =>
 
           switch (type) {
             case "hash": {
-              console.log(value);
               whereClause = Prisma.sql`WHERE b.hash = ${value}`;
               break;
             }


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
Add support for using labels (latest, oldest) as block IDs, allowing retrieval of the most recent or earliest block without needing an explicit hash or number.

#### Motivation and Context (Optional)

### Related Issue (Optional)

### Screenshots (if appropriate):
