### PR TITLE
fix: correct typo in blob storage log message

### DIFF
--- a/packages/api/src/routers/indexer/indexData.ts
+++ b/packages/api/src/routers/indexer/indexData.ts
@@ -131,7 +131,7 @@ export const indexData = createAuthedProcedure("indexer")
     p1 = performance.now();
 
     logger.debug(
-      `Block ${input.block.number} blob data stored in primay blob storage: ${
+      `Block ${input.block.number} blob data stored in primary blob storage: ${
         propagatorInput.length
       } blobs uploaded! (${p1 - p0}ms)`
     );


### PR DESCRIPTION

 Corrected "primay" → "primary" in `packages/api/src/routers/indexer/indexData.ts`

