### PR TITLE
perf(db): improve eth usd price queries

### DIFF
--- a/.changeset/big-wolves-hide.md
+++ b/.changeset/big-wolves-hide.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/db": patch
+---
+
+Optimized eth usd price queries with a `LEFT JOIN` to short-circuit lookups

--- a/packages/db/prisma/extensions/eth-usd-price.ts
+++ b/packages/db/prisma/extensions/eth-usd-price.ts
@@ -90,7 +90,7 @@ export const ethUsdPriceExtension = Prisma.defineExtension((prisma) =>
           return startBlockModelFnSpan("findEthUsdPrice", async () => {
             const ethUsdPrice = await prisma.$queryRaw<EthUsdPrice[]>`
               SELECT p.id, p.price, p.timestamp
-              FROM block b join eth_usd_price p on DATE_TRUNC('minute', b.timestamp) = p.timestamp
+              FROM block b left join eth_usd_price p on DATE_TRUNC('minute', b.timestamp) = p.timestamp
               ${whereClause}
               ${orderBy}
             `;
@@ -114,7 +114,7 @@ export const ethUsdPriceExtension = Prisma.defineExtension((prisma) =>
 
             const ethUsdPrice = await prisma.$queryRaw<EthUsdPrice[]>`
               SELECT p.id, p.price, p.timestamp
-              FROM block b join eth_usd_price p on DATE_TRUNC('minute', b.timestamp) = p.timestamp
+              FROM block b left join eth_usd_price p on DATE_TRUNC('minute', b.timestamp) = p.timestamp
               ${whereClause}
               ${orderByClause}
               LIMIT 1
@@ -128,7 +128,7 @@ export const ethUsdPriceExtension = Prisma.defineExtension((prisma) =>
         async findEthUsdPrice(txHash: string) {
           const ethUsdPrice = await prisma.$queryRaw<EthUsdPrice[]>`
               SELECT p.id, p.price, p.timestamp
-              FROM transaction tx join eth_usd_price p on DATE_TRUNC('minute', tx.block_timestamp) = p.timestamp
+              FROM transaction tx left join eth_usd_price p on DATE_TRUNC('minute', tx.block_timestamp) = p.timestamp
               WHERE tx.hash = ${txHash}
             `;
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
It adds a `LEFT JOIN` to query to short-circuit lookup and prevent scanning the whole table

#### Motivation and Context (Optional)
In testnet Blobscan instances, ETH-USD price queries can be slow because of missing price data. This caused the database to scan the entire table due to the join condition. By switching to a LEFT JOIN, the query short-circuits when no price is found, avoiding full table scans and significantly improving performance.
### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
