### PR TITLE
fix(api): resolve app state retrieval issue

### DIFF
--- a/.changeset/curvy-vans-share.md
+++ b/.changeset/curvy-vans-share.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/api": patch
+---
+
+Resolved an issue where the app state wasn't being returned if the blob storage state is absent

--- a/packages/api/src/routers/state/getAppState.ts
+++ b/packages/api/src/routers/state/getAppState.ts
@@ -8,8 +8,8 @@ type StateQuery = {
   lastFinalizedBlock: number;
   lastLowerSyncedSlot: number;
   lastUpperSyncedSlot: number;
-  swarmDataId: number;
-  swarmDataTTL: number;
+  swarmDataId?: number;
+  swarmDataTTL?: number;
 }[];
 
 type BlocksQuery = {
@@ -32,7 +32,7 @@ export const getAppState = publicProcedure.query(
         st.last_upper_synced_slot AS "lastUpperSyncedSlot",
         bs.swarm_data_id AS "swarmDataId",
         bs.swarm_data_ttl AS "swarmDataTTL"
-      FROM blockchain_sync_state st JOIN blob_storages_state bs ON st.id = bs.id
+      FROM blockchain_sync_state st LEFT JOIN blob_storages_state bs ON st.id = bs.id
       WHERE st.id = 1;
     `,
       prisma.$queryRaw<BlocksQuery>`


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
This PR switches to a LEFT JOIN, allowing the query to return app state even when no blob storage state is present.

#### Motivation and Context (Optional)
Prevents missing app state data when blob storage state is absent.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
