### PR TITLE
fix(rest-api-server): send stable visitor ID (cid) in Matomo tracking

### DIFF
--- a/.changeset/matomo-stable-visitor-id.md
+++ b/.changeset/matomo-stable-visitor-id.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/rest-api-server": patch
+---
+
+Fix Matomo unique visitor tracking by sending a stable `cid` (visitor ID) per client. Authenticated clients get a deterministic ID derived from their bearer token hash; anonymous clients fall back to an IP + User-Agent hash. Authenticated clients also get `uid` for cross-session tracking. Also fixed `pf_srv` to correctly measure request duration.

--- a/apps/rest-api-server/src/clients/matomo-tracker.ts
+++ b/apps/rest-api-server/src/clients/matomo-tracker.ts
@@ -14,6 +14,8 @@ interface TrackOptions {
   action_name?: string;
   ua?: string;
   cip?: string;
+  cid?: string;
+  uid?: string;
   cvar?: string;
   cvar2?: string;
   lang?: string;

--- a/apps/rest-api-server/src/middlewares/matomo.ts
+++ b/apps/rest-api-server/src/middlewares/matomo.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto";
+
 import type { Request, Response, NextFunction } from "express";
 
 import { env } from "@blobscan/env";
@@ -43,6 +45,42 @@ function shouldSkipTracking(req: Request): boolean {
   });
 }
 
+function hashToHex(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+/**
+ * Extract the bearer token from the Authorization header, if present.
+ */
+function getBearerToken(req: Request): string | undefined {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader) {
+    return;
+  }
+
+  const [type, token] = authHeader.split(" ");
+
+  return type === "Bearer" && token ? token : undefined;
+}
+
+/**
+ * Generate a stable 16-character hex visitor ID for Matomo's `cid` parameter.
+ *
+ * Priority:
+ *  1. Hash of the bearer token (authenticated clients)
+ *  2. Hash of IP + User-Agent (anonymous clients)
+ */
+function getVisitorId(req: Request): string {
+  const token = getBearerToken(req);
+
+  if (token) {
+    return hashToHex(token);
+  }
+
+  return hashToHex(`${getClientIp(req)}:${req.headers["user-agent"] || "unknown"}`);
+}
+
 export function matomoMiddleware(
   req: Request,
   res: Response,
@@ -60,9 +98,9 @@ export function matomoMiddleware(
     return;
   }
 
-  res.on("finish", () => {
-    const start = Date.now();
+  const start = Date.now();
 
+  res.on("finish", () => {
     const clientIp = getClientIp(req);
     const userAgent = req.headers["user-agent"] || "unknown";
     const acceptLanguage = req.headers["accept-language"] || "unknown";
@@ -75,6 +113,9 @@ export function matomoMiddleware(
 
     const fullUrl = `${req.protocol}://${req.get("host") || "unknown"}${url}`;
 
+    const visitorId = getVisitorId(req);
+    const bearerToken = getBearerToken(req);
+
     matomoTracker
       ?.track({
         url: fullUrl,
@@ -82,6 +123,8 @@ export function matomoMiddleware(
         token_auth: env.MATOMO_AUTH_TOKEN,
         ua: userAgent,
         cip: clientIp,
+        cid: visitorId,
+        ...(bearerToken && { uid: hashToHex(bearerToken) }),
         lang: acceptLanguage,
         pf_srv: (Date.now() - start).toString(),
         cvar: JSON.stringify({


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

 send stable visitor ID (cid) in Matomo tracking

#### Motivation and Context (Optional)

Without cid, Matomo cannot deduplicate API clients in cookie-less mode, causing unique visitors to always equal total visits.

- Derive cid from bearer token hash (authenticated) or IP+UA hash (anonymous)
- Send uid (hashed bearer token) for authenticated clients for cross-session tracking
- No user-supplied headers are trusted for identity
- Fix pf_srv measurement by capturing start time before finish handler

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
