### PR TITLE
updated getByBlockID documentation and local installation guide

### DIFF
--- a/apps/docs/src/app/docs/running-blobscan-locally/page.md
+++ b/apps/docs/src/app/docs/running-blobscan-locally/page.md
@@ -8,7 +8,7 @@ nextjs:
 
 ## Requirements
 
-- [Node.js 18+](https://nodejs.org/)
+- [Node.js 20](https://nodejs.org/)
 - [pnpm](https://pnpm.io/)
 - [docker compose](https://docs.docker.com/compose/)
 

--- a/packages/api/src/routers/block/getByBlockId.ts
+++ b/packages/api/src/routers/block/getByBlockId.ts
@@ -31,6 +31,7 @@ export const getByBlockId = publicProcedure
       path: `/blocks/{id}`,
       tags: ["blocks"],
       summary: "retrieves block details for given block number or hash.",
+      description: "This endpoint retrieves block details for given block number or hash. However, blocks are only stored if they contain blobs. If a valid block id is entered, but that blob does not contain any blobs, then the endpoint will return an error."
     },
   })
   .input(inputSchema)


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
I added a description to the getByBlockID endpoint so that users know that only blocks with blobs can be returned. I changed the local installation guide to say that Node 20 is required.

#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
