### PR TITLE
perf(db): add index on storage column in blob_data_storage_reference

### DIFF
--- a/packages/db/prisma/migrations/20260612000000_add_storage_index_to_blob_data_storage_reference/migration.sql
+++ b/packages/db/prisma/migrations/20260612000000_add_storage_index_to_blob_data_storage_reference/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "blob_data_storage_reference_storage_idx" ON "blob_data_storage_reference"("storage");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -213,6 +213,7 @@ model BlobDataStorageReference {
   blob Blob @relation(fields: [blobHash], references: [versionedHash])
 
   @@id([blobHash, blobStorage])
+  @@index([blobStorage])
   @@map("blob_data_storage_reference")
 }
 


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

  The composite PK (blob_hash, storage) cannot serve queries that filter by storage alone, since blob_hash is the leading column. This causes full sequential scans for queries like COUNT(*) WHERE storage = 'google'.

  This PR adds a dedicated index on the storage column, enabling index-only scans for those queries.

#### Motivation and Context (Optional)

  Benchmarked on mainnet staging (~19M rows):

  ```┌───────────────────────────────────┬───────────────────────┬────────────────────────┐
  │               Query               │        Before         │         After          │
  ├───────────────────────────────────┼───────────────────────┼────────────────────────┤
  │ COUNT(*) WHERE storage = 'google' │ 21s (seq scan)        │ 3.5s (index only scan) │
  ├───────────────────────────────────┼───────────────────────┼────────────────────────┤
  │ SELECT * WHERE blob_hash = '...'  │ 2.6ms (PK index scan) │ 2.6ms (unchanged)      │
  └───────────────────────────────────┴───────────────────────┴────────────────────────
```

Alternative considered: reordering the PK to (storage, blob_hash) — this destroyed blob_hash lookup performance (2.6ms → 19.6s) with no benefit, so it was ruled out.

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
