### PR TITLE
fix(storage): retry health check on transient startup failures

### DIFF
--- a/.changeset/storage-healthcheck-retry.md
+++ b/.changeset/storage-healthcheck-retry.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/blob-storage-manager": patch
+---
+
+Retry blob storage health checks on startup so a transient network failure (e.g. a premature connection close while fetching a GCS auth token) no longer aborts boot. The reachability probe now uses up to 4 attempts with exponential backoff and jitter before declaring a storage unreachable.

--- a/packages/blob-storage-manager/src/BlobStorage.ts
+++ b/packages/blob-storage-manager/src/BlobStorage.ts
@@ -9,6 +9,16 @@ export interface BlobStorageConfig {
   signedUrlsEnabled?: boolean;
 }
 
+// Number of extra attempts after the first one when probing reachability at
+// startup. A transient network blip (e.g. a premature close while fetching a
+// GCS auth token) shouldn't abort boot.
+const HEALTH_CHECK_MAX_RETRIES = 3;
+const HEALTH_CHECK_RETRY_BASE_DELAY_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export interface GetBlobOpts {
   fileType?: BlobFileType;
 }
@@ -41,15 +51,35 @@ export abstract class BlobStorage {
   }
 
   protected async healthCheck(): Promise<"OK"> {
-    try {
-      await this._healthCheck();
+    let lastErr: unknown;
 
-      return "OK";
-    } catch (err) {
-      throw new Error("Storage is not reachable", {
-        cause: err as Error,
-      });
+    for (let attempt = 0; attempt <= HEALTH_CHECK_MAX_RETRIES; attempt++) {
+      try {
+        await this._healthCheck();
+
+        return "OK";
+      } catch (err) {
+        lastErr = err;
+
+        if (attempt >= HEALTH_CHECK_MAX_RETRIES) {
+          break;
+        }
+
+        // Exponential backoff with jitter so transient network failures
+        // (timeouts, premature connection closes) get a few chances before
+        // we declare the storage unreachable.
+        const backoffMs =
+          HEALTH_CHECK_RETRY_BASE_DELAY_MS *
+          2 ** attempt *
+          (0.5 + Math.random() * 0.5);
+
+        await sleep(backoffMs);
+      }
     }
+
+    throw new Error("Storage is not reachable", {
+      cause: lastErr as Error,
+    });
   }
 
   async getBlob(uri: string): Promise<string> {


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Adds retry-with-backoff to BlobStorage.healthCheck() — the shared base-class method that every storage backend's create() calls before being added to the manager:

- Up to 4 attempts (1 initial + 3 retries)
- Exponential backoff with jitter (~500ms / ~1s / ~2s × 0.5–1.0), matching the existing retry style in IpfsStorage
- Only after all attempts are exhausted does it throw the original "Storage is not reachable" error, preserving the underlying failure as cause

#### Motivation and Context (Optional)

The REST API server aborts startup when its primary blob storage fails its initial reachability check — even when the failure is a transient network hiccup rather than a real misconfiguration. We observed this in staging:

```
  StorageCreationError: GoogleStorage failed: Creation failed: Storage is not reachable
    cause: FetchError: Invalid response body while trying to fetch
           https://www.googleapis.com/oauth2/v4/token: Premature close
  ...
  Primary blob storage "GOOGLE" was not created.
```

The root cause was a premature connection close while fetching a GCS OAuth2 token — a one-off transport blip, not a credentials or config problem (which would surface as a 4xx). Because GOOGLE is the primary storage,
  createBlobPropagator then refused to start the server. Meanwhile other services (e.g. eth-price-syncer) had no trouble reaching the internet, confirming the failure was transient and storage-specific.

A single network blip at boot should not take down the API.


### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
