### PR TITLE
fix(rollups): match blob poster addresses case-insensitively

### DIFF
--- a/packages/rollups/src/RollupRegistry.ts
+++ b/packages/rollups/src/RollupRegistry.ts
@@ -41,8 +41,16 @@ export class RollupRegistry {
   }
 
   getRollup(blobPoster: string) {
+    const normalizedBlobPoster = blobPoster.toLowerCase();
     const rollup = Object.entries(this.registry).find(([_, blobPosters]) => {
-      return blobPosters.includes(blobPoster);
+      if (!blobPosters) {
+        return false;
+      }
+
+      return blobPosters.some(
+        (registeredBlobPoster) =>
+          registeredBlobPoster.toLowerCase() === normalizedBlobPoster
+      );
     });
 
     if (!rollup) {

--- a/packages/rollups/test/RollupRegistry.test.ts
+++ b/packages/rollups/test/RollupRegistry.test.ts
@@ -50,6 +50,12 @@ describe("RollupRegistry", () => {
       ).toEqual("MODE");
     });
 
+    it("should match blob posters case-insensitively", () => {
+      expect(
+        rollupRegistry.getRollup("0x18df96b5f89bd1452554382d88017c424704ae04")
+      ).toEqual("NAL");
+    });
+
     it("should return no rollup for a blob poster that does not exist", () => {
       expect(rollupRegistry.getRollup("0x12321312321321321321")).toEqual(null);
     });


### PR DESCRIPTION
### Checklist

- [ ] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [ ] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

Update `RollupRegistry.getRollup` to compare blob poster addresses case-insensitively.

Some registry entries are stored as checksum/mixed-case addresses, while transaction addresses can be lowercased before lookup. This could cause `getRollup` to miss a known blob poster and return `null`. The lookup now normalizes both sides before comparing, without changing the stored registry values.


#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):

