### PR TITLE
feat(web): add IPFS migration banner

### DIFF
--- a/.changeset/ipfs-migration-banner.md
+++ b/.changeset/ipfs-migration-banner.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": minor
+---
+
+Add a banner announcing the migration to IPFS-based blob storage

--- a/apps/web/src/components/AppLayout/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout/AppLayout.tsx
@@ -1,7 +1,7 @@
 import cn from "classnames";
 
 import { useIsHomepage } from "~/hooks/useIsHomePage";
-// import Banner from "./Banner";
+import Banner from "./Banner";
 import { BottomBarLayout } from "./BottomBarLayout";
 import { TopBarLayout } from "./TopBarLayout";
 
@@ -15,7 +15,7 @@ const AppLayout = ({ children }: LayoutProps) => {
 
   return (
     <div className="flex min-h-screen flex-col">
-      {/* <Banner /> */}
+      <Banner />
       <TopBarLayout />
       <main
         className={cn("container mx-auto grow", {

--- a/apps/web/src/components/AppLayout/Banner.tsx
+++ b/apps/web/src/components/AppLayout/Banner.tsx
@@ -39,27 +39,17 @@ export default function Banner() {
         />
       </div>
       <div className="flex flex-col items-center gap-y-1 text-sm">
-        <div className="flex flex-wrap items-center gap-x-4">
+        <div className="flex flex-wrap items-center justify-center gap-x-2">
           <p className="leading-6 text-content-light dark:text-content-dark">
-            ⚡ Blobscan needs your support! We only have 6 months of runway.
+            🌐 Blobscan is migrating to IPFS. Mainnet blobs remain permanently
+            pinned on IPFS. Sepolia and Hoodi blobs are now served via IPFS on a
+            best-effort basis without pinning guarantees.
           </p>
           <Link
-            href="https://paragraph.com/@blobscan/blobscan-the-cost-of-archiving-ethereums-blob-data"
+            href="https://paragraph.com/@blobscan/announcing-transition-to-decentralized-blob-storage"
             isExternal
           >
-            Read our latest blog post
-          </Link>
-        </div>
-        <div className="flex flex-wrap items-center gap-x-4">
-          <p className="leading-6 text-content-light dark:text-content-dark">
-            The good news: we&apos;re part of the TheDAO Security Fund Quadratic
-            Funding Round — every donation is amplified.
-          </p>
-          <Link
-            href="https://qf.giveth.io/project/blobscan?roundId=16"
-            isExternal
-          >
-            Donate on Giveth
+            Learn more →
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Re-enables the site-wide banner (which already existed but was disabled) with a new message announcing Blobscan's migration to IPFS-based blob storage:

> 🌐 Blobscan is migrating to IPFS. Mainnet blobs remain permanently pinned on IPFS. Sepolia and Hoodi blobs are now served via IPFS on a best-effort basis without pinning guarantees. **[Learn more →]**

The "Learn more →" links to the [announcement post](https://paragraph.com/@blobscan/announcing-transition-to-decentralized-blob-storage).

## Changes

- `apps/web/src/components/AppLayout/Banner.tsx` — replace previous banner content with the IPFS migration message and link.
- `apps/web/src/components/AppLayout/AppLayout.tsx` — uncomment the import and `<Banner />` to re-enable it.
- Added a minor changeset for `@blobscan/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)