### PR TITLE
fix(api): order /blocks by slot when slot-filtered; fix logger.warning crash

### DIFF
--- a/.changeset/fix-blocks-slow-query-and-logger-warn.md
+++ b/.changeset/fix-blocks-slow-query-and-logger-warn.md
@@ -1,0 +1,6 @@
+---
+"@blobscan/api": patch
+"@blobscan/rest-api-server": patch
+---
+
+Fixed slow GET /blocks queries when filtering by slot range by ordering on `slot` instead of `number` (~9.5s → ~5ms). Fixed a REST API crash from the Matomo middleware calling the non-existent `logger.warning()`.

--- a/apps/rest-api-server/src/middlewares/matomo.ts
+++ b/apps/rest-api-server/src/middlewares/matomo.ts
@@ -133,7 +133,7 @@ export function matomoMiddleware(
         }),
       })
       .catch((error) => {
-        logger.warning(`Failed to track request ${actionName} `, error);
+        logger.warn(`Failed to track request ${actionName} `, error);
       });
   });
 

--- a/packages/api/src/routers/block/getAll.ts
+++ b/packages/api/src/routers/block/getAll.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@blobscan/db";
 import { z } from "@blobscan/zod";
 
 import {
@@ -55,6 +56,16 @@ export const getAll = publicProcedure
       sort,
     } = filters;
 
+    // `slot` and `number` are monotonically correlated, so when the request
+    // filters by a slot range we order by `slot` to let Postgres satisfy both
+    // the range predicate and the ordering from the `slot` index alone. Ordering
+    // by `number` here forces a full scan of the `number` index, discarding
+    // millions of out-of-range rows (see EXPLAIN: ~9s vs ~5ms). The resulting
+    // order is identical because both columns increase together.
+    const orderBy: Prisma.BlockOrderByWithRelationInput = blockFilters.slot
+      ? { slot: sort }
+      : { number: sort };
+
     const blocksOp = prisma.block.findMany({
       select: createBlockSelect(expands, filters),
       where: {
@@ -66,7 +77,7 @@ export const getAll = publicProcedure
             }
           : undefined,
       },
-      orderBy: { number: sort },
+      orderBy,
       ...pagination,
     });
     const countOp = count


### PR DESCRIPTION
### Checklist

- [] My change requires a documentation update, and I have done it.
- [ ] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description

Two production issues in the REST API:

1. GET /blocks with a slot range took ~9.5s and starved Prisma's connection pool. The query filtered on `slot` but ordered by `number`, so Postgres scanned the entire `number` index and discarded millions of out-of-range rows (EXPLAIN: block_number_idx scan, "Rows Removed by Filter: 2740916", 8.6s). Since `slot` and `number` are monotonically correlated, ordering by `slot` when a slot filter is present lets Postgres range-scan the `slot` index for both the predicate and the ordering. Verified: 8712ms -> 5.5ms, identical result order.

2. The Matomo middleware called logger.warning() on tracking failure, but the winston logger only defines warn(). This threw "logger.warning is not a function" as an unhandled promise rejection, crashing the API process (observed 684 restarts in production). Use logger.warn().


#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->

### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
