### PR TITLE
perf(db): drop redundant indexes

### DIFF
--- a/.changeset/drop-redundant-indexes.md
+++ b/.changeset/drop-redundant-indexes.md
@@ -1,0 +1,13 @@
+---
+"@blobscan/db": patch
+---
+
+Drop three redundant database indexes
+
+`transaction(from_id, block_timestamp)` is a strict prefix of
+`transaction(from_id, block_timestamp, index)`,
+`blobs_on_transactions(tx_hash)` is a prefix of both the primary key
+`(tx_hash, index)` and `(tx_hash, blob_hash)`, and
+`address(address, rollup)` leads with the primary-key column. Every query
+they served is served identically by the longer index or primary key, so
+they only added write and storage overhead on the largest tables.

--- a/packages/db/prisma/migrations/20260715000000_drop_redundant_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20260715000000_drop_redundant_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex: strict prefix of "transaction_from_id_block_timestamp_index_idx"
+DROP INDEX IF EXISTS "transaction_from_id_block_timestamp_idx";
+
+-- DropIndex: strict prefix of both the primary key (tx_hash, index) and "blobs_on_transactions_tx_hash_blob_hash_idx"
+DROP INDEX IF EXISTS "blobs_on_transactions_tx_hash_idx";
+
+-- DropIndex: leads with the primary key column; rollup-only filters use "address_rollup_idx"
+DROP INDEX IF EXISTS "address_address_rollup_idx";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -170,7 +170,6 @@ model Address {
   transactionsAsSender   Transaction[] @relation("senderAddressRelation")
   transactionsAsReceiver Transaction[] @relation("receiverAddressRelation")
 
-  @@index([address, rollup])
   @@index([rollup])
   @@index([firstBlockNumberAsReceiver])
   @@index([firstBlockNumberAsSender])
@@ -280,7 +279,6 @@ model Transaction {
   @@index([blockTimestamp, index])
   @@index([blockNumber, index])
   @@index([fromId, blockTimestamp, index])
-  @@index([fromId, blockTimestamp]) // Rollup queries by time
   @@index([toId, blockTimestamp, index])
   @@index([insertedAt])
   @@map("transaction")
@@ -307,7 +305,6 @@ model BlobsOnTransactions {
   @@index([blockNumber, txIndex, index])
   @@index([blobHash])
   @@index([blockHash])
-  @@index([txHash])
   @@index([txHash, blobHash]) // Transaction-blob joins
   @@index([blockTimestamp, txHash]) // Time-based blob queries
   @@map("blobs_on_transactions")


### PR DESCRIPTION
## Description

An index audit cross-referencing every `@@index` declaration in `schema.prisma` against all query sites (tRPC routers in `@blobscan/api`, raw-SQL Prisma extensions, typed aggregation SQL, and the syncers) found no missing indexes — but it did find three that are provably redundant:

| Dropped index | Made redundant by |
|---|---|
| `transaction(from_id, block_timestamp)` | strict prefix of `transaction(from_id, block_timestamp, index)` |
| `blobs_on_transactions(tx_hash)` | prefix of both the PK `(tx_hash, index)` and `(tx_hash, blob_hash)` |
| `address(address, rollup)` | leads with the PK column (`address`); rollup-only filters use `address(rollup)` |

A B-tree index on `(a, b, c)` serves every query an index on `(a, b)` serves, so these drops cannot regress any query plan. They only added write amplification and storage on the two hottest-write tables (`transaction`, `blobs_on_transactions`).

## Deployment note

For a zero-lock rollout the drops can be applied manually with `DROP INDEX CONCURRENTLY`; the migration uses `DROP INDEX IF EXISTS`, so it stays consistent either way.

## Possible follow-up (not in this PR)

The `inserted_at` indexes on `address`, `blob`, `block`, and `transaction` are not queried anywhere in the codebase. Before dropping them, confirm they are idle in production:

```sql
SELECT relname, indexrelname, idx_scan FROM pg_stat_user_indexes
WHERE indexrelname LIKE '%inserted_at%' ORDER BY idx_scan;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
