### PR TITLE
perf(db): convert inserted_at indexes to BRIN

### DIFF
--- a/.changeset/brin-inserted-at-indexes.md
+++ b/.changeset/brin-inserted-at-indexes.md
@@ -1,0 +1,12 @@
+---
+"@blobscan/db": patch
+---
+
+Convert the `inserted_at` B-tree indexes to BRIN
+
+The `inserted_at` indexes on `address`, `blob`, `block`, and `transaction`
+are not used by any application query and `inserted_at` is nearly
+monotonically increasing on these append-mostly tables, which is the ideal
+BRIN case: the index shrinks from one entry per row to one min/max summary
+per block range, with near-zero write overhead, while still supporting
+ad-hoc time-range queries.

--- a/packages/db/prisma/migrations/20260715000001_convert_inserted_at_indexes_to_brin/migration.sql
+++ b/packages/db/prisma/migrations/20260715000001_convert_inserted_at_indexes_to_brin/migration.sql
@@ -1,0 +1,28 @@
+-- Convert the inserted_at B-tree indexes to BRIN. inserted_at is nearly
+-- monotonically increasing on these append-mostly tables, so a BRIN index
+-- provides equivalent range-scan pruning at a small fraction of the size
+-- and with near-zero write overhead.
+
+-- DropIndex
+DROP INDEX IF EXISTS "address_inserted_at_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "blob_inserted_at_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "block_inserted_at_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "transaction_inserted_at_idx";
+
+-- CreateIndex
+CREATE INDEX "address_inserted_at_idx" ON "address" USING BRIN ("inserted_at");
+
+-- CreateIndex
+CREATE INDEX "blob_inserted_at_idx" ON "blob" USING BRIN ("inserted_at");
+
+-- CreateIndex
+CREATE INDEX "block_inserted_at_idx" ON "block" USING BRIN ("inserted_at");
+
+-- CreateIndex
+CREATE INDEX "transaction_inserted_at_idx" ON "transaction" USING BRIN ("inserted_at");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -174,7 +174,7 @@ model Address {
   @@index([rollup])
   @@index([firstBlockNumberAsReceiver])
   @@index([firstBlockNumberAsSender])
-  @@index([insertedAt])
+  @@index([insertedAt], type: Brin)
   @@map("address")
 }
 
@@ -194,7 +194,7 @@ model Blob {
 
   @@index([firstBlockNumber])
   @@index([proof])
-  @@index([insertedAt])
+  @@index([insertedAt], type: Brin)
   @@map("blob")
 }
 
@@ -242,7 +242,7 @@ model Block {
   transactionForks    TransactionFork[]
 
   @@index([number])
-  @@index([insertedAt])
+  @@index([insertedAt], type: Brin)
   @@map("block")
 }
 
@@ -282,7 +282,7 @@ model Transaction {
   @@index([fromId, blockTimestamp, index])
   @@index([fromId, blockTimestamp]) // Rollup queries by time
   @@index([toId, blockTimestamp, index])
-  @@index([insertedAt])
+  @@index([insertedAt], type: Brin)
   @@map("transaction")
 }
 


### PR DESCRIPTION
## Description

Follow-up to #1003. The `inserted_at` indexes on `address`, `blob`, `block`, and `transaction` are not used by any query in the codebase, but rather than dropping them outright (they may serve ad-hoc ops/analytics queries outside the repo), this converts them from B-tree to BRIN, keeping the same index names.

## Why BRIN fits here

BRIN stores one min/max summary per range of physical pages instead of one entry per row. It is only effective when the column's values correlate with physical row order — which is exactly the case for `inserted_at`: rows are appended in insertion order on these append-mostly tables, so each page-range summary covers a narrow time window and a time-range query (`WHERE inserted_at > …`) skips nearly all of the table.

Compared to the current B-trees:

- **Size**: one summary per ~1 MB of table instead of one entry per row — typically 100–1000× smaller on tables like `transaction`.
- **Write cost**: near zero (update a min/max summary) instead of tree maintenance on every insert.
- **Trade-off**: no point lookups, `ORDER BY` support, or uniqueness — none of which anything in the codebase needs on this column.

## Deployment note

`CREATE INDEX` (non-concurrent) takes a lock that blocks writes for the duration of the build. BRIN builds are fast (single sequential scan, tiny output), but on the large production tables the drops/creates can instead be applied manually with `DROP INDEX CONCURRENTLY` / `CREATE INDEX CONCURRENTLY … USING BRIN`; the migration uses the same index names, so it remains consistent either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)