### PR TITLE
perf(db): drop unused inserted_at indexes

### DIFF
--- a/.changeset/drop-inserted-at-indexes.md
+++ b/.changeset/drop-inserted-at-indexes.md
@@ -1,0 +1,10 @@
+---
+"@blobscan/db": patch
+---
+
+Drop the unused `inserted_at` indexes
+
+No application query filters or orders by `inserted_at` on `address`,
+`blob`, `block`, or `transaction`, and production index statistics show
+zero scans over the database's entire lifetime while the four indexes
+occupied ~635 MB combined and added maintenance work to every insert.

--- a/packages/db/prisma/migrations/20260715000001_drop_inserted_at_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20260715000001_drop_inserted_at_indexes/migration.sql
@@ -1,0 +1,15 @@
+-- Drop the inserted_at indexes: no application query filters or orders by
+-- inserted_at, and production statistics (idx_scan = 0 with stats never
+-- reset) show they have never been used, while occupying ~635 MB combined.
+
+-- DropIndex
+DROP INDEX IF EXISTS "address_inserted_at_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "blob_inserted_at_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "block_inserted_at_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "transaction_inserted_at_idx";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -174,7 +174,6 @@ model Address {
   @@index([rollup])
   @@index([firstBlockNumberAsReceiver])
   @@index([firstBlockNumberAsSender])
-  @@index([insertedAt])
   @@map("address")
 }
 
@@ -194,7 +193,6 @@ model Blob {
 
   @@index([firstBlockNumber])
   @@index([proof])
-  @@index([insertedAt])
   @@map("blob")
 }
 
@@ -242,7 +240,6 @@ model Block {
   transactionForks    TransactionFork[]
 
   @@index([number])
-  @@index([insertedAt])
   @@map("block")
 }
 
@@ -282,7 +279,6 @@ model Transaction {
   @@index([fromId, blockTimestamp, index])
   @@index([fromId, blockTimestamp]) // Rollup queries by time
   @@index([toId, blockTimestamp, index])
-  @@index([insertedAt])
   @@map("transaction")
 }
 


### PR DESCRIPTION
## Description

Follow-up to #1003 and replacement for #1004. The `inserted_at` indexes on `address`, `blob`, `block`, and `transaction` are not used by any query in the codebase, and production statistics now confirm they have never been used at all:

```
   relname   |        indexrelname         | idx_scan |  size
-------------+-----------------------------+----------+---------
 address     | address_inserted_at_idx     |        0 | 5480 kB
 blob        | blob_inserted_at_idx        |        0 | 378 MB
 block       | block_inserted_at_idx       |        0 | 97 MB
 transaction | transaction_inserted_at_idx |        0 | 155 MB
```

`stats_reset` is NULL for the database, so these counters span its entire statistics lifetime — zero scans, ever, in-repo or ad-hoc. Dropping them frees ~635 MB and removes index maintenance from every insert on the largest tables.

#1004 proposed converting these to BRIN as a hedge in case they served occasional out-of-repo queries; the production numbers show there is nothing to hedge, so that PR is closed in favor of this one.

## Deployment note

The drops can be applied manually with `DROP INDEX CONCURRENTLY` for a zero-lock rollout; the migration uses `DROP INDEX IF EXISTS`, so it stays consistent either way. If a time-range ad-hoc query is ever needed later, a tiny BRIN index (as in #1004) can be added back cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)