### PR TITLE
fix(web): decode Postgres blob data as hex bytes

### DIFF
--- a/.changeset/fix-postgres-blob-data-decoding.md
+++ b/.changeset/fix-postgres-blob-data-decoding.md
@@ -1,0 +1,5 @@
+---
+"@blobscan/web": patch
+---
+
+Fixed Postgres-backed blob data being returned as UTF-8 encoded hexadecimal characters instead of the original binary bytes.

--- a/apps/web/src/pages/api/blob-data.ts
+++ b/apps/web/src/pages/api/blob-data.ts
@@ -62,7 +62,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
         });
       }
 
-      blobData = Buffer.from(data.slice(2));
+      blobData = Buffer.from(data.slice(2), "hex");
     } else if (isTextPlainFile) {
       const data = await response.text();
 

--- a/apps/web/test/api/blob-data.test.ts
+++ b/apps/web/test/api/blob-data.test.ts
@@ -1,0 +1,69 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "../../src/pages/api/blob-data";
+
+vi.mock("~/env", () => ({
+  env: {
+    BLOB_DATA_API_KEY: undefined,
+  },
+}));
+
+function createMockReq(): NextApiRequest {
+  return {
+    query: {
+      storage: "postgres",
+      url: "https://api.example.com/blobs/0x123/data",
+    },
+  } as unknown as NextApiRequest;
+}
+
+function createMockRes() {
+  const res = {
+    statusCode: 0,
+    body: null as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: unknown) {
+      res.body = data;
+      return res;
+    },
+    send(data: unknown) {
+      res.body = data;
+      return res;
+    },
+    setHeader: vi.fn(),
+  };
+
+  return res as unknown as NextApiResponse & {
+    statusCode: number;
+    body: unknown;
+  };
+}
+
+describe("GET /api/blob-data", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: () => "application/json",
+        },
+        json: async () => "0x0001feff",
+      })
+    );
+  });
+
+  it("decodes hex blob data returned by Postgres storage", async () => {
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(Buffer.from([0x00, 0x01, 0xfe, 0xff]));
+  });
+});


### PR DESCRIPTION
### Checklist

- [x] My change requires a documentation update, and I have done it.
- [x] I have added tests to cover my changes.
- [x] I have filled out the description and linked the related issues.

### Description
<!--Please include a summary of the change and which issue is fixed.-->

Fix the blob data proxy response for Postgres-backed storage references.

The Postgres blob data endpoint returns a JSON string containing `0x`-prefixed hexadecimal data. The proxy previously passed the hexadecimal characters to `Buffer.from()` without specifying an encoding, causing them to be interpreted as UTF-8 text instead of the original binary bytes.

This change decodes the value using the `hex` encoding, matching the existing handling for text-based storage responses.


#### Motivation and Context (Optional)
<!--Please include relevant motivation and context.-->


For example, `0x0001feff` was previously returned as the bytes representing the ASCII string `0001feff` (`3030303166656666`) instead of the expected binary bytes (`0001feff`).

A regression test now verifies that Postgres-backed responses preserve the original blob bytes.


### Related Issue (Optional)
<!-- List any dependencies that are required for this change.-->

### Screenshots (if appropriate):
